### PR TITLE
fix Scala version checking in build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ val versionSpecificScalaSource = {
     val sv = (scalaVersion in Compile).value
     val baseDirectory = (scalaSource in Compile).value
     val versionSpecificSources =
-      new File(baseDirectory.getAbsolutePath + "-" + (if (sv == scala213) "2.13+" else "2.13-"))
+      new File(baseDirectory.getAbsolutePath + "-" + (if (CrossVersion.partialVersion(sv) == Some((2, 13))) "2.13+" else "2.13-"))
     versionSpecificSources +: current
   }
 }


### PR DESCRIPTION
required for the Scala community build, where the Scala version
is liable to be something like "2.13.3-bin-b2bc991"