### PR TITLE
Base implementation for Scala 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ out
 .js
 .jvm
 .native
+.metals/
+.bloop/
+project/**/metals.sbt
+.vscode/
+.bsp

--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ If `props` contains an entry for `"NumReports"`, then `.atOrElse` behaves the sa
 parameter is never evaluated. If there is no entry, then `.atOrElse` will make one using the second parameter
  and perform subsequent modifications on the newly instantiated default.
  
- For Options, `.atOrElse` takes no arguments and acts similarly. 
+For Options, `.atOrElse` takes no arguments and acts similarly. 
  
  ````scala
- person.modify(_.addresses.at(2).street.atOrElse(Street("main street")).name).using(_.toUpperCase)
+person.modify(_.addresses.at(2).street.atOrElse(Street("main street")).name).using(_.toUpperCase)
  ````
  
  `.atOrElse` is currently not available for sequences because quicklens might need to insert many
@@ -215,14 +215,14 @@ Alternate syntax:
 ````scala
 import com.softwaremill.quicklens._
 
-val modifyStreetName = modify[Person](_.address.street.name)
+val modifyStreetName = modifyLens[Person](_.address.street.name)
 
 val p3 = modifyStreetName.using(_.toUpperCase)(person)
 val p4 = modifyStreetName.using(_.toLowerCase)(anotherPerson)
 
 //
 
-val upperCaseStreetName = modify[Person](_.address.street.name).using(_.toUpperCase)
+val upperCaseStreetName = modifyLens[Person](_.address.street.name).using(_.toUpperCase)
 
 val p5 = upperCaseStreetName(person)
 ````
@@ -241,8 +241,8 @@ or, with alternate syntax:
 ````scala
 import com.softwaremill.quicklens._
 
-val modifyAddress = modify[Person](_.address)
-val modifyStreetName = modify[Address](_.street.name)
+val modifyAddress = modifyLens[Person](_.address)
+val modifyStreetName = modifyLens[Address](_.street.name)
 
 val p6 = (modifyAddress andThenModify modifyStreetName).using(_.toUpperCase)(person)
 ````

--- a/build.sbt
+++ b/build.sbt
@@ -60,16 +60,32 @@ val versionSpecificScalaSources = {
   }
 }
 
+def compilerLibrary(scalaVersion: String) = {
+  if (scalaVersion == scala3) {
+    Seq.empty
+  } else {
+    Seq("org.scala-lang" % "scala-compiler" % scalaVersion % Test)
+  }
+}
+
+def reflectLibrary(scalaVersion: String) = {
+  if (scalaVersion == scala3) {
+    Seq.empty
+  } else {
+    Seq("org.scala-lang" % "scala-reflect" % scalaVersion % Provided)
+  }
+}
+
 lazy val quicklens = (projectMatrix in file("quicklens"))
   .settings(buildSettings)
   .settings(
     name := "quicklens",
-    libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
+    libraryDependencies ++= reflectLibrary(scalaVersion.value),
     Test / publishArtifact := false,
-    libraryDependencies ++= Seq("org.scala-lang" % "scala-compiler" % scalaVersion.value % Test),
+    libraryDependencies ++= compilerLibrary(scalaVersion.value),
     versionSpecificScalaSources,
     libraryDependencies ++= Seq("flatspec", "shouldmatchers").map(m =>
-      "org.scalatest" %%% s"scalatest-$m" % "3.2.3" % Test
+      "org.scalatest" %%% s"scalatest-$m" % "3.2.4" % Test
     )
   )
   .jvmPlatform(

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 val scala211 = "2.11.12"
 val scala212 = "2.12.12"
 val scala213 = "2.13.4"
+val scala3 = "3.0.0-RC1"
 
 val buildSettings = Seq(
   organization := "com.softwaremill.quicklens",
@@ -72,10 +73,10 @@ lazy val quicklens = (projectMatrix in file("quicklens"))
     )
   )
   .jvmPlatform(
-    scalaVersions = List(scala211, scala212, scala213)
+    scalaVersions = List(scala211, scala212, scala213, scala3)
   )
   .jsPlatform(
-    scalaVersions = List(scala212, scala213)
+    scalaVersions = List(scala212, scala213, scala3)
   )
   .nativePlatform(
     scalaVersions = List(scala211),

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val scala211 = "2.11.12"
 val scala212 = "2.12.12"
 val scala213 = "2.13.4"
-val scala3 = "3.0.0-RC2"
+val scala3 = "3.0.0-RC3"
 
 val buildSettings = Seq(
   organization := "com.softwaremill.quicklens",
@@ -85,7 +85,7 @@ lazy val quicklens = (projectMatrix in file("quicklens"))
     libraryDependencies ++= compilerLibrary(scalaVersion.value),
     versionSpecificScalaSources,
     libraryDependencies ++= Seq("flatspec", "shouldmatchers").map(m =>
-      "org.scalatest" %%% s"scalatest-$m" % "3.2.7" % Test
+      "org.scalatest" %%% s"scalatest-$m" % "3.2.8" % Test
     )
   )
   .jvmPlatform(

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val scala3 = "3.0.0-RC3"
 
 val buildSettings = Seq(
   organization := "com.softwaremill.quicklens",
-  scalacOptions := Seq("-deprecation", "-feature", "-unchecked"),
+  scalacOptions := Seq("-deprecation", "-feature", "-unchecked"), // useful for debugging macros: "-Ycheck:all"
   // Sonatype OSS deployment
   publishTo := Some(
     if (isSnapshot.value)

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val scala211 = "2.11.12"
 val scala212 = "2.12.12"
 val scala213 = "2.13.4"
-val scala3 = "3.0.0-RC1"
+val scala3 = "3.0.0-RC2"
 
 val buildSettings = Seq(
   organization := "com.softwaremill.quicklens",
@@ -85,7 +85,7 @@ lazy val quicklens = (projectMatrix in file("quicklens"))
     libraryDependencies ++= compilerLibrary(scalaVersion.value),
     versionSpecificScalaSources,
     libraryDependencies ++= Seq("flatspec", "shouldmatchers").map(m =>
-      "org.scalatest" %%% s"scalatest-$m" % "3.2.4" % Test
+      "org.scalatest" %%% s"scalatest-$m" % "3.2.7" % Test
     )
   )
   .jvmPlatform(
@@ -97,7 +97,6 @@ lazy val quicklens = (projectMatrix in file("quicklens"))
   .nativePlatform(
     scalaVersions = List(scala211),
     settings = Seq(
-      libraryDependencies ++= Seq("org.scala-native" %%% "test-interface" % "0.4.0-M2" % Test),
       nativeLinkStubs := true
     )
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.6
+sbt.version=1.5.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.4.0")
-val scalaNativeVersion = Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.0-M2")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.5.1")
+val scalaNativeVersion = Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
@@ -14,5 +14,3 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
 addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.7.0")
-
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.1")

--- a/quicklens/src/main/scala-2.13+/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-2.13+/com.softwaremill.quicklens/package.scala
@@ -122,9 +122,9 @@ package object quicklens {
     }
   }
 
-  def modify[T]: LensHelper[T] = LensHelper[T]()
+  def modifyLens[T]: LensHelper[T] = LensHelper[T]()
 
-  def modifyAll[T]: MultiLensHelper[T] = MultiLensHelper[T]()
+  def modifyAllLens[T]: MultiLensHelper[T] = MultiLensHelper[T]()
 
   case class LensHelper[T] private () {
 

--- a/quicklens/src/main/scala-2.13+/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-2.13+/com.softwaremill.quicklens/package.scala
@@ -270,7 +270,7 @@ package object quicklens {
     override def atOrElse(fa: M[K, T], key: K, default: => T)(f: T => T): M[K, T] =
       fa.updated(key, f(fa.getOrElse(key, default))).to(fac)
     override def index(fa: M[K, T], key: K)(f: T => T): M[K, T] =
-        fa.get(key).map(f).fold(fa)(t => fa.updated(key, t).to(fac))
+      fa.get(key).map(f).fold(fa)(t => fa.updated(key, t).to(fac))
     override def each(fa: M[K, T])(f: (T) => T): M[K, T] = {
       fa.view.mapValues(f).to(fac)
     }

--- a/quicklens/src/main/scala-2.13-/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-2.13-/com.softwaremill.quicklens/package.scala
@@ -123,9 +123,9 @@ package object quicklens {
     }
   }
 
-  def modify[T]: LensHelper[T] = LensHelper[T]()
+  def modifyLens[T]: LensHelper[T] = LensHelper[T]()
 
-  def modifyAll[T]: MultiLensHelper[T] = MultiLensHelper[T]()
+  def modifyAllLens[T]: MultiLensHelper[T] = MultiLensHelper[T]()
 
   case class LensHelper[T] private () {
 

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -1,5 +1,6 @@
 package com.softwaremill
 
+import scala.collection.Factory
 import scala.annotation.compileTimeOnly
 import scala.quoted.*
 
@@ -172,7 +173,7 @@ package object quicklens {
     }
 
     given [K, M <: ([V] =>> Map[K, V])] : QuicklensFunctor[M] with {
-      def map[A, B](fa: M[A], f: A => B): M[B] = fa.view.mapValues(f).toMap.asInstanceOf[M[B]]
+      def map[A, B](fa: M[A], f: A => B): M[B] = fa.view.mapValues(f).to(fa.mapFactory.mapFactory[K, B]).asInstanceOf[M[B]]
     }
   }
 
@@ -308,7 +309,7 @@ package object quicklens {
 
   def modifyImpl[S, A](obj: Expr[S], focus: Expr[S => A])(using qctx: Quotes, tpeS: Type[S], tpeA: Type[A]): Expr[PathModify[S, A]] = {
     import qctx.reflect.*
-    
+
     def unsupportedShapeInfo(tree: Tree) = s"Unsupported path element. Path must have shape: _.field1.field2.each.field3.(...), got: $tree"
 
     def methodSupported(method: String) =

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -237,20 +237,24 @@ package object quicklens {
 
   extension [T[_, _], L, R](e: T[L, R])(using f: QuicklensEitherFunctor[T, L, R])
     @compileTimeOnly(canOnlyBeUsedInsideModify("eachLeft"))
-    def eachLeft: L = sys.error("")
+    def eachLeft: L = ???
 
     @compileTimeOnly(canOnlyBeUsedInsideModify("eachRight"))
-    def eachRight: R = sys.error("")
+    def eachRight: R = ???
 
   extension [F[_], T](t: F[T])(using f: QuicklensSingleAtFunctor[F, T])
     @compileTimeOnly(canOnlyBeUsedInsideModify("at"))
-    def at: T = sys.error("")
+    def at: T = ???
 
     @compileTimeOnly(canOnlyBeUsedInsideModify("atOrElse"))
-    def atOrElse(default: => T): T = sys.error("")
+    def atOrElse(default: => T): T = ???
 
     @compileTimeOnly(canOnlyBeUsedInsideModify("index"))
-    def index: T = sys.error("")
+    def index: T = ???
+
+  extension [A](value: A)
+    @compileTimeOnly(canOnlyBeUsedInsideModify("when"))
+    def when[B <: A]: B = ???
 
   extension [T, U](f1: T => PathModify[T, U])
     def andThenModify[V](f2: U => PathModify[U, V]): T => PathModify[T, V] = (t: T) =>

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -362,10 +362,13 @@ package object quicklens {
           if(i == idx) namedArg
           else Select(objTerm, termMethodByNameUnsafe(objTerm, "copy$default$" + i.toString))
         }.toList
-        Apply(
-          Select(objTerm, copy),
-          args
-        )
+
+        objTerm.tpe.widen match {
+          // if the object's type is parametrised, we need to call .copy with the same type parameters
+          case AppliedType(_, typeParams) => Apply(TypeApply(Select(objTerm, copy), typeParams.map(Inferred(_))), args)
+          case _ => Apply(Select(objTerm, copy), args)
+        }
+
       /**
         * For FunctionDelegate(method, givn, T, args)
         * 

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -191,7 +191,7 @@ package object quicklens {
       def at[A](fa: M[A], f: A => A, idx: K): M[A] =
         fa.updated(idx, f(fa(idx))).asInstanceOf[M[A]]
       def atOrElse[A](fa: M[A], f: A => A, idx: K, default: => A): M[A] =
-        fa.updated(idx, f(fa.applyOrElse(idx, Function.const(default)))).asInstanceOf[M[A]]
+        fa.updated(idx, f(fa.applyOrElse(idx, _ => default))).asInstanceOf[M[A]]
       def index[A](fa: M[A], f: A => A, idx: K): M[A] =
         if fa.isDefinedAt(idx) then fa.updated(idx, f(fa(idx))).asInstanceOf[M[A]] else fa
     }

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -353,25 +353,44 @@ package object quicklens {
       (caseFields.find(_.name == name).get, idx+1)
     }
 
+    def caseClassCopy(mod: Expr[A => A], obj: Term, field: PathSymbol.Field, tail: Seq[PathSymbol]): Term =
+      if (!obj.tpe.typeSymbol.flags.is(Flags.Case)) then
+        report.throwError(s"Unsupported source object: must be a case class or sealed trait, but got: $obj")
+
+      val copy = termMethodByNameUnsafe(obj, "copy")
+      val (fieldMethod, idx) = termAccessorMethodByNameUnsafe(obj, field.name)
+      val namedArg = NamedArg(field.name, mapToCopy(mod, Select(obj, fieldMethod), tail))
+      val fieldsIdxs = 1.to(obj.tpe.typeSymbol.caseFields.length)
+      val args = fieldsIdxs.map { i =>
+        if(i == idx) namedArg
+        else Select(obj, termMethodByNameUnsafe(obj, "copy$default$" + i.toString))
+      }.toList
+
+      obj.tpe.widen match {
+        // if the object's type is parametrised, we need to call .copy with the same type parameters
+        case AppliedType(_, typeParams) => Apply(TypeApply(Select(obj, copy), typeParams.map(Inferred(_))), args)
+        case _ => Apply(Select(obj, copy), args)
+      }
+
     def mapToCopy(mod: Expr[A => A], objTerm: Term, path: Seq[PathSymbol]): Term = path match
       case Nil =>
         val apply = termMethodByNameUnsafe(mod.asTerm, "apply")
         Apply(Select(mod.asTerm, apply), List(objTerm))
       case (field: PathSymbol.Field) :: tail =>
-        val copy = termMethodByNameUnsafe(objTerm, "copy")
-        val (fieldMethod, idx) = termAccessorMethodByNameUnsafe(objTerm, field.name)
-        val namedArg = NamedArg(field.name, mapToCopy(mod, Select(objTerm, fieldMethod), tail))
-        val fieldsIdxs = 1.to(objTerm.tpe.typeSymbol.caseFields.length)
-        val args = fieldsIdxs.map { i =>
-          if(i == idx) namedArg
-          else Select(objTerm, termMethodByNameUnsafe(objTerm, "copy$default$" + i.toString))
-        }.toList
+        val objSymbol = objTerm.tpe.typeSymbol
+        if (objSymbol.flags.is(Flags.Case)) then
+          caseClassCopy(mod, objTerm, field, tail)
+        else if (objSymbol.flags.is(Flags.Sealed) && objSymbol.flags.is(Flags.Trait)) then
+          // if the source is a sealed trait, generating a pattern match with a .copy for each child (implementing case class)
+          val cases = objTerm.tpe.typeSymbol.children.map { child =>
+            val subtype = TypeIdent(child)
+            val bind = Symbol.newBind(Symbol.spliceOwner, "c", Flags.EmptyFlags, subtype.tpe)
+            CaseDef(Bind(bind, Typed(objTerm, subtype)), None, caseClassCopy(mod, Ref(bind), field, tail))
+          }
+          Match(objTerm, cases)
 
-        objTerm.tpe.widen match {
-          // if the object's type is parametrised, we need to call .copy with the same type parameters
-          case AppliedType(_, typeParams) => Apply(TypeApply(Select(objTerm, copy), typeParams.map(Inferred(_))), args)
-          case _ => Apply(Select(objTerm, copy), args)
-        }
+        else
+          report.throwError(s"Unsupported source object: must be a case class or sealed trait, but got: $objSymbol")
 
       /**
         * For FunctionDelegate(method, givn, T, args)

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -1,0 +1,202 @@
+package com.softwaremill
+
+import scala.quoted.*
+
+package object quicklens {
+
+  /**
+    * Create an object allowing modifying the given (deeply nested) field accessible in a `case class` hierarchy
+    * via `path` on the given `obj`.
+    *
+    * All modifications are side-effect free and create copies of the original objects.
+    *
+    * You can use `.each` to traverse options, lists, etc.
+    */
+  extension [S, A](inline obj: S)
+    inline def modify(inline path: S => A): PathModify[S, A] = ${ modifyImpl('obj, 'path) }
+
+  case class PathModify[S, A](obj: S, f: (A => A) => S) {
+    
+    /**
+      * Transform the value of the field(s) using the given function.
+      *
+      * @return A copy of the root object with the (deeply nested) field(s) modified.
+      */
+    def using(mod: A => A): S = f.apply(mod)
+
+    /** An alias for [[using]]. Explicit calls to [[using]] are preferred over this alias, but quicklens provides
+      * this option because code auto-formatters (like scalafmt) will generally not keep [[modify]]/[[using]]
+      * pairs on the same line, leading to code like
+      * {{{
+      * x
+      *   .modify(_.foo)
+      *   .using(newFoo :: _)
+      *   .modify(_.bar)
+      *   .using(_ + newBar)
+      * }}}
+      * When using [[apply]], scalafmt will allow
+      * {{{
+      * x
+      *   .modify(_.foo)(newFoo :: _)
+      *   .modify(_.bar)(_ + newBar)
+      * }}}
+      * */
+    def apply(mod: A => A): S = using(mod)
+
+    /**
+      * Transform the value of the field(s) using the given function, if the condition is true. Otherwise, returns the
+      * original object unchanged.
+      *
+      * @return A copy of the root object with the (deeply nested) field(s) modified, if `condition` is true.
+      */
+    def usingIf(condition: Boolean)(mod: A => A): S = if condition then using(mod) else obj
+
+    /**
+      * Set the value of the field(s) to a new value.
+      *
+      * @return A copy of the root object with the (deeply nested) field(s) set to the new value.
+      */
+    def setTo(v: A): S = f.apply(Function.const(v))
+
+    /**
+        * Set the value of the field(s) to a new value, if it is defined. Otherwise, returns the original object
+        * unchanged.
+        *
+        * @return A copy of the root object with the (deeply nested) field(s) set to the new value, if it is defined.
+        */
+    def setToIfDefined(v: Option[A]): S = v.fold(obj)(setTo)
+
+    /**
+      * Set the value of the field(s) to a new value, if the condition is true. Otherwise, returns the original object
+      * unchanged.
+      *
+      * @return A copy of the root object with the (deeply nested) field(s) set to the new value, if `condition` is
+      *         true.
+      */
+    def setToIf(condition: Boolean)(v: A): S = if condition then setTo(v) else obj
+  }
+
+  trait QuicklensFunctor[F[_]] {
+    def map[A, B](fa: F[A], f: A => B): F[B]
+  }
+
+  object QuicklensFunctor {
+    given QuicklensFunctor[List] with {
+      def map[A, B](fa: List[A], f: A => B): List[B] = fa.map(f)
+    }
+
+    given QuicklensFunctor[Seq] with {
+      def map[A, B](fa: Seq[A], f: A => B): Seq[B] = fa.map(f)
+    }
+
+    given QuicklensFunctor[Option] with {
+      def map[A, B](fa: Option[A], f: A => B): Option[B] = fa.map(f)
+    }
+  }
+
+  extension [F[_]: QuicklensFunctor, A](fa: F[A])
+    def each: A = ???
+
+  private val shapeInfo = "focus must have shape: _.field1.each.field3"
+
+  def toPathModify[S: Type, A: Type](obj: Expr[S], f: Expr[(A => A) => S])(using Quotes): Expr[PathModify[S, A]] = '{ PathModify( ${obj}, ${f} ) }
+
+  def to[T: Type, R: Type](f: Expr[T] => Expr[R])(using Quotes): Expr[T => R] = '{ (x: T) => ${ f('x) } }
+
+  def modifyImpl[S, A](obj: Expr[S], focus: Expr[S => A])(using qctx: Quotes, tpeS: Type[S], tpeA: Type[A]): Expr[PathModify[S, A]] = {
+    import qctx.reflect.*
+
+    enum PathSymbol:
+      case Field(name: String)
+      case Each(givn: Term, typeTree: TypeTree)
+
+    object PathSymbol {
+      def specialSymbolByName(term: Term, methodName: String, typeTree: TypeTree): PathSymbol = methodName match {
+        case "each" => Each(term, typeTree)
+        case _ =>
+          report.error(shapeInfo)
+          ???
+      }
+    }
+
+    def toPath(tree: Tree): Seq[PathSymbol] = {
+      tree match {
+        case Select(deep, ident) =>
+          toPath(deep) :+ PathSymbol.Field(ident)
+        case Apply(Apply(TypeApply(Ident(s), typeTrees), idents), List(ident: Ident)) =>
+          idents.flatMap(toPath) :+ PathSymbol.specialSymbolByName(ident, s, typeTrees.last)
+        case Apply(deep, idents) =>
+          toPath(deep) ++ idents.flatMap(toPath)
+        case i: Ident if i.name.startsWith("_") =>
+          Seq.empty
+        case _ =>
+          report.error(shapeInfo)
+          ???
+      }
+    }
+
+    def termMethodByNameUnsafe(term: Term, name: String): Symbol = {
+      term.tpe.typeSymbol.declaredMethod(name).head
+    }
+
+    def termAccessorMethodByNameUnsafe(term: Term, name: String): (Symbol, Int) = {
+      val caseFields = term.tpe.typeSymbol.caseFields
+      val idx = caseFields.map(_.name).indexOf(name)
+      (caseFields.find(_.name == name).get, idx+1)
+    }
+
+    def mapToCopy[X](mod: Expr[A => A], objTerm: Term, path: Seq[PathSymbol]): Term = path match
+      case Nil =>
+        val apply = termMethodByNameUnsafe(mod.asTerm, "apply")
+        Apply(Select(mod.asTerm, apply), List(objTerm))
+      case (field: PathSymbol.Field) :: tail =>
+        val copy = termMethodByNameUnsafe(objTerm, "copy")
+        val (fieldMethod, idx) = termAccessorMethodByNameUnsafe(objTerm, field.name)
+        val namedArg = NamedArg(field.name, mapToCopy(mod, Select(objTerm, fieldMethod), tail))
+        val fieldsIdxs = 1.to(objTerm.tpe.typeSymbol.caseFields.length)
+        val args = fieldsIdxs.map { i =>
+          if(i == idx) namedArg
+          else Select(objTerm, termMethodByNameUnsafe(objTerm, "copy$default$" + i.toString))
+        }.toList
+        Apply(
+          Select(objTerm, copy),
+          args
+        )
+      case (m: PathSymbol.Each) :: tail =>
+        val defdefSymbol = Symbol.newMethod(
+          Symbol.spliceOwner,
+          "$anonfun",
+          MethodType(List("x"))(_ => List(m.typeTree.tpe), _ => m.typeTree.tpe)
+        )
+        val mapMethod = termMethodByNameUnsafe(m.givn, "map")
+        val map = TypeApply(
+          Select(m.givn, mapMethod),
+          List(m.typeTree, m.typeTree)
+        )
+        val defdefStatements = DefDef(
+          defdefSymbol, {
+            case List(List(x)) => Some(mapToCopy(mod, x.asExpr.asTerm, tail))
+          }
+        )
+        val closure = Closure(Ref(defdefSymbol), None)
+        val block = Block(List(defdefStatements), closure)
+        Apply(map, List(objTerm, block))
+    
+    val focusTree: Tree = focus.asTerm
+    val path = focusTree match {
+      case Inlined(_, _, Block(List(DefDef(_, _, _, Some(p))), _)) =>
+        toPath(p)
+      case _ =>
+        report.error(shapeInfo)
+        ???
+    }
+
+    val objTree: Tree = obj.asTerm
+    val objTerm: Term = objTree match {
+      case Inlined(_, _, term) => term
+    }
+    
+    val res: (Expr[A => A] => Expr[S]) = (mod: Expr[A => A]) => mapToCopy(mod, objTerm, path).asExpr.asInstanceOf[Expr[S]]
+    toPathModify(obj, to(res))
+  }
+}

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -198,25 +198,25 @@ package object quicklens {
   }
 
   trait QuicklensEitherFunctor[T[_, _], L, R]:
-    def eachLeft[A](e: T[L, R], f: L => L): T[L, R]
-    def eachRight[A](e: T[L, R], f: R => R): T[L, R]
+    def eachLeft[A](e: T[A, R], f: A => A): T[A, R]
+    def eachRight[A](e: T[L, A], f: A => A): T[L, A]
 
   object QuicklensEitherFunctor:
     given [L, R]: QuicklensEitherFunctor[Either, L, R] with
-      override def eachLeft[A](e: Either[L, R], f: (L) => L) = e.left.map(f)
-      override def eachRight[A](e: Either[L, R], f: (R) => R) = e.map(f)
+      override def eachLeft[A](e: Either[A, R], f: A => A) = e.left.map(f)
+      override def eachRight[A](e: Either[L, A], f: A => A) = e.map(f)
   
   // Currently only used for [[Option]], but could be used for [[Right]]-biased [[Either]]s.
-  trait QuicklensSingleAtFunctor[F[_], T]:
-    def at(fa: F[T])(f: T => T): F[T]
-    def atOrElse(fa: F[T], default: => T)(f: T => T): F[T]
-    def index(fa: F[T])(f: T => T): F[T]
+  trait QuicklensSingleAtFunctor[F[_]]:
+    def at[A](fa: F[A], f: A => A): F[A]
+    def atOrElse[A](fa: F[A], f: A => A, default: => A): F[A]
+    def index[A](fa: F[A], f: A => A): F[A]
 
   object QuicklensSingleAtFunctor:
-    given [A]: QuicklensSingleAtFunctor[Option, A] with
-      override def at(fa: Option[A])(f: A => A): Option[A] = Some(fa.map(f).get)
-      override def atOrElse(fa: Option[A], default: => A)(f: A => A): Option[A] = fa.orElse(Some(default)).map(f)
-      override def index(fa: Option[A])(f: A => A): Option[A] = fa.map(f)
+    given QuicklensSingleAtFunctor[Option] with
+      override def at[A](fa: Option[A], f: A => A): Option[A] = Some(fa.map(f).get)
+      override def atOrElse[A](fa: Option[A], f: A => A, default: => A): Option[A] = fa.orElse(Some(default)).map(f)
+      override def index[A](fa: Option[A], f: A => A): Option[A] = fa.map(f)
 
   extension [F[_]: QuicklensFunctor, A](fa: F[A])
     @compileTimeOnly(canOnlyBeUsedInsideModify("each"))
@@ -243,7 +243,7 @@ package object quicklens {
     @compileTimeOnly(canOnlyBeUsedInsideModify("eachRight"))
     def eachRight: R = ???
 
-  extension [F[_], T](t: F[T])(using f: QuicklensSingleAtFunctor[F, T])
+  extension [F[_]: QuicklensSingleAtFunctor, T](t: F[T])
     @compileTimeOnly(canOnlyBeUsedInsideModify("at"))
     def at: T = ???
 

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -230,6 +230,10 @@ package object quicklens {
     @compileTimeOnly(canOnlyBeUsedInsideModify("eachRight"))
     def eachRight: R = sys.error("")
 
+  extension [T, U](f1: T => PathModify[T, U])
+    def andThenModify[V](f2: U => PathModify[U, V]): T => PathModify[T, V] = (t: T) =>
+      PathModify[T, V](t, vv => f1(t).f(u => f2(u).f(vv)))
+
   private def canOnlyBeUsedInsideModify(method: String) = s"$method can only be used as a path component inside modify"
 
   //

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -167,7 +167,7 @@ package object quicklens {
     def atOrElse(idx: I, default: => A): A = ???
     def index(idx: I): A = ???
 
-  private val shapeInfo = "focus must have shape: _.field1.each.field3"
+  private val shapeInfo = "Path must have shape: _.field1.field2.each.field3.(...)"
 
   def toPathModify[S: Type, A: Type](obj: Expr[S], f: Expr[(A => A) => S])(using Quotes): Expr[PathModify[S, A]] = '{ PathModify( ${obj}, ${f} ) }
 

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -216,8 +216,7 @@ package object quicklens {
         case i: Ident if i.name.startsWith("_") =>
           Seq.empty
         case _ =>
-          report.error(shapeInfo)
-          ???
+          report.throwError(shapeInfo)
       }
     }
 
@@ -275,8 +274,7 @@ package object quicklens {
       case Block(List(DefDef(_, _, _, Some(p))), _) =>
         toPath(p)
       case _ =>
-        report.error(shapeInfo)
-        ???
+        report.throwError(shapeInfo)
     }
 
     val objTree: Tree = obj.asTerm

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -377,8 +377,8 @@ package object quicklens {
           case AppliedType(_, typeParams) => Apply(TypeApply(Select(obj, copy), typeParams.map(Inferred(_))), args)
           case _ => Apply(Select(obj, copy), args)
         }
-      else if objSymbol.flags.is(Flags.Sealed) && objSymbol.flags.is(Flags.Trait) then
-        // if the source is a sealed trait, generating a pattern match with a .copy for each child (implementing case class)
+      else if (objSymbol.flags.is(Flags.Sealed) && objSymbol.flags.is(Flags.Trait)) || objSymbol.flags.is(Flags.Enum) then
+        // if the source is a sealed trait / enum, generating a pattern match with a .copy for each child (implementing case class)
         val cases = obj.tpe.typeSymbol.children.map { child =>
           val subtype = TypeIdent(child)
           val bind = Symbol.newBind(owner, "c", Flags.EmptyFlags, subtype.tpe)

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -4,25 +4,49 @@ import scala.quoted.*
 
 package object quicklens {
 
-  extension [S, A](inline obj: S)
-    /**
-      * Create an object allowing modifying the given (deeply nested) field accessible in a `case class` hierarchy
-      * via `path` on the given `obj`.
-      *
-      * All modifications are side-effect free and create copies of the original objects.
-      *
-      * You can use `.each` to traverse options, lists, etc.
-      */
-    inline def modify(inline path: S => A): PathModify[S, A] = ${ modifyImpl('obj, 'path) }
-    /**
-      * Create an object allowing modifying the given (deeply nested) fields accessible in a `case class` hierarchy
-      * via `paths` on the given `obj`.
-      *
-      * All modifications are side-effect free and create copies of the original objects.
-      *
-      * You can use `.each` to traverse options, lists, etc.
-      */
-    inline def modifyAll(inline path: S => A, inline paths: (S => A)*) : PathModify[S, A] = ${ modifyAllImpl('obj, 'path, 'paths) }
+  trait ModifyPimp {
+    extension [S, A](inline obj: S)
+      /**
+        * Create an object allowing modifying the given (deeply nested) field accessible in a `case class` hierarchy
+        * via `path` on the given `obj`.
+        *
+        * All modifications are side-effect free and create copies of the original objects.
+        *
+        * You can use `.each` to traverse options, lists, etc.
+        */
+      inline def modify(inline path: S => A): PathModify[S, A] = ${ modifyImpl('obj, 'path) }
+      /**
+        * Create an object allowing modifying the given (deeply nested) fields accessible in a `case class` hierarchy
+        * via `paths` on the given `obj`.
+        *
+        * All modifications are side-effect free and create copies of the original objects.
+        *
+        * You can use `.each` to traverse options, lists, etc.
+        */
+      inline def modifyAll(inline path: S => A, inline paths: (S => A)*) : PathModify[S, A] = ${ modifyAllImpl('obj, 'path, 'paths) }
+  }
+
+  given modifyPimp: ModifyPimp with {}
+
+  /**
+    * Create an object allowing modifying the given (deeply nested) field accessible in a `case class` hierarchy
+    * via `path` on the given `obj`.
+    *
+    * All modifications are side-effect free and create copies of the original objects.
+    *
+    * You can use `.each` to traverse options, lists, etc.
+    */
+  inline def modify[S, A](inline obj: S)(inline path: S => A): PathModify[S, A] =${ modifyImpl('obj, 'path) }
+
+  /**
+    * Create an object allowing modifying the given (deeply nested) fields accessible in a `case class` hierarchy
+    * via `paths` on the given `obj`.
+    *
+    * All modifications are side-effect free and create copies of the original objects.
+    *
+    * You can use `.each` to traverse options, lists, etc.
+    */
+  inline def modifyAll[S, A](inline obj: S)(inline path: S => A, inline paths: (S => A)*) : PathModify[S, A] = ${ modifyAllImpl('obj, 'path, 'paths) }
 
   case class PathModify[S, A](obj: S, f: (A => A) => S) {
     

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -385,7 +385,7 @@ package object quicklens {
       /** Single inlined path */
       case Inlined(_, _, Block(List(DefDef(_, _, _, Some(p))), _)) =>
         toPath(p)
-      /** One of paths from modifyAll, stripped from `Inlined` in modifyAllImpl */
+      /** One of paths from modifyAll */
       case Block(List(DefDef(_, _, _, Some(p))), _) =>
         toPath(p)
       case _ =>

--- a/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com.softwaremill.quicklens/package.scala
@@ -176,7 +176,7 @@ package object quicklens {
       def map[A, B](fa: M[A], f: A => B): M[B] = {
         val mapped = fa.view.mapValues(f)
         (fa match {
-          case sfa: SortedMap[A, B] => sfa.sortedMapFactory.from(mapped)(using sfa.ordering)
+          case sfa: SortedMap[K, A] => sfa.sortedMapFactory.from(mapped)(using sfa.ordering)
           case _ => mapped.to(fa.mapFactory)
         }).asInstanceOf[M[B]]
       }

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/ModifyEnumTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/ModifyEnumTest.scala
@@ -1,0 +1,22 @@
+package com.softwaremill.quicklens
+
+import com.softwaremill.quicklens.TestData.duplicate
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+object EnumTestData {
+  enum P3(val a: String):
+    case C5(override val a: String, b: Int) extends P3(a)
+    case C6(override val a: String, c: Option[String]) extends P3(a)
+
+  val p3: P3 = P3.C5("c2", 0)
+  val p3dup: P3 = P3.C5("c2c2", 0)
+}
+
+class ModifyEnumTest extends AnyFlatSpec with Matchers {
+  import EnumTestData._
+
+  it should "modify a field in an enum case" in {
+    modify(p3)(_.a).using(duplicate) should be(p3dup)
+  }
+}

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/LensLazyTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/LensLazyTest.scala
@@ -6,15 +6,15 @@ import org.scalatest.matchers.should.Matchers
 
 class LensLazyTest extends AnyFlatSpec with Matchers {
   it should "create reusable lens of the given type" in {
-    val lens = modify[A1](_.a2.a3.a4.a5.name)
+    val lens = modifyLens[A1](_.a2.a3.a4.a5.name)
 
     val lm = lens.using(duplicate)
     lm(a1) should be(a1dup)
   }
 
   it should "compose lens" in {
-    val lens_a1_a3 = modify[A1](_.a2.a3)
-    val lens_a3_name = modify[A3](_.a4.a5.name)
+    val lens_a1_a3 = modifyLens[A1](_.a2.a3)
+    val lens_a3_name = modifyLens[A3](_.a4.a5.name)
 
     val lm = (lens_a1_a3 andThenModify lens_a3_name).using(duplicate)
     lm(a1) should be(a1dup)

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyLazyTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyLazyTest.scala
@@ -6,27 +6,27 @@ import org.scalatest.matchers.should.Matchers
 
 class ModifyLazyTest extends AnyFlatSpec with Matchers {
   it should "modify a single-nested case class field" in {
-    val ml = modify[A5](_.name).using(duplicate)
+    val ml = modifyLens[A5](_.name).using(duplicate)
     ml(a5) should be(a5dup)
   }
 
   it should "modify a deeply-nested case class field" in {
-    val ml = modify[A1](_.a2.a3.a4.a5.name).using(duplicate)
+    val ml = modifyLens[A1](_.a2.a3.a4.a5.name).using(duplicate)
     ml(a1) should be(a1dup)
   }
 
   it should "modify several fields" in {
-    val ml = modifyAll[B1](_.b2, _.b3.each).using(duplicate)
+    val ml = modifyAllLens[B1](_.b2, _.b3.each).using(duplicate)
     ml(b1) should be(b1dupdup)
   }
 
   it should "modify a case class field if the condition is true" in {
-    val ml = modify[A5](_.name).usingIf(true)(duplicate)
+    val ml = modifyLens[A5](_.name).usingIf(true)(duplicate)
     ml(a5) should be(a5dup)
   }
 
   it should "leave a case class unchanged if the condition is flase" in {
-    val ml = modify[A5](_.name).usingIf(false)(duplicate)
+    val ml = modifyLens[A5](_.name).usingIf(false)(duplicate)
     ml(a5) should be(a5)
   }
 }


### PR DESCRIPTION
Base features from Scala 2 should work.
TODO list:
- [x] `modifyAll`
- [x] `eachWhere`
- [x] `at`
- [x] `index`
- [x] `polimorphic classes`
- [x] `lens helpers`
- [x] `Map`s
- [x] `Option`s
- [x] `Either`s
- [x] `when`
- [x] sealed traits
