### PR TITLE
Fix import problems in scala 3.0.0

### DIFF
--- a/quicklens/src/main/scala-3/com/softwaremill/quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com/softwaremill/quicklens/package.scala
@@ -5,49 +5,26 @@ import scala.annotation.compileTimeOnly
 import com.softwaremill.quicklens.QuicklensMacros._
 
 package object quicklens {
-  trait ModifyPimp {
-    extension [S, A](inline obj: S)
-      /**
-        * Create an object allowing modifying the given (deeply nested) field accessible in a `case class` hierarchy
-        * via `path` on the given `obj`.
-        *
-        * All modifications are side-effect free and create copies of the original objects.
-        *
-        * You can use `.each` to traverse options, lists, etc.
-        */
-      inline def modify(inline path: S => A): PathModify[S, A] = ${ modifyImpl('obj, 'path) }
-      /**
-        * Create an object allowing modifying the given (deeply nested) fields accessible in a `case class` hierarchy
-        * via `paths` on the given `obj`.
-        *
-        * All modifications are side-effect free and create copies of the original objects.
-        *
-        * You can use `.each` to traverse options, lists, etc.
-        */
-      inline def modifyAll(inline path: S => A, inline paths: (S => A)*) : PathModify[S, A] = ${ modifyAllImpl('obj, 'path, 'paths) }
-  }
 
-  given modifyPimp: ModifyPimp with {}
-
-  /**
-    * Create an object allowing modifying the given (deeply nested) field accessible in a `case class` hierarchy
-    * via `path` on the given `obj`.
-    *
-    * All modifications are side-effect free and create copies of the original objects.
-    *
-    * You can use `.each` to traverse options, lists, etc.
-    */
-  inline def modify[S, A](inline obj: S)(inline path: S => A): PathModify[S, A] =${ modifyImpl('obj, 'path) }
-
-  /**
-    * Create an object allowing modifying the given (deeply nested) fields accessible in a `case class` hierarchy
-    * via `paths` on the given `obj`.
-    *
-    * All modifications are side-effect free and create copies of the original objects.
-    *
-    * You can use `.each` to traverse options, lists, etc.
-    */
-  inline def modifyAll[S, A](inline obj: S)(inline path: S => A, inline paths: (S => A)*) : PathModify[S, A] = ${ modifyAllImpl('obj, 'path, 'paths) }
+  extension [S, A](inline obj: S)
+    /**
+      * Create an object allowing modifying the given (deeply nested) field accessible in a `case class` hierarchy
+      * via `path` on the given `obj`.
+      *
+      * All modifications are side-effect free and create copies of the original objects.
+      *
+      * You can use `.each` to traverse options, lists, etc.
+      */
+    inline def modify(inline path: S => A): PathModify[S, A] = ${ modifyImpl('obj, 'path) }
+    /**
+      * Create an object allowing modifying the given (deeply nested) fields accessible in a `case class` hierarchy
+      * via `paths` on the given `obj`.
+      *
+      * All modifications are side-effect free and create copies of the original objects.
+      *
+      * You can use `.each` to traverse options, lists, etc.
+      */
+    inline def modifyAll(inline path: S => A, inline paths: (S => A)*) : PathModify[S, A] = ${ modifyAllImpl('obj, 'path, 'paths) }
 
   case class PathModify[S, A](obj: S, f: (A => A) => S) {
     

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ModifyEnumTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ModifyEnumTest.scala
@@ -1,8 +1,10 @@
-package com.softwaremill.quicklens
+package com.softwaremill.quicklens.test
 
 import com.softwaremill.quicklens.TestData.duplicate
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import com.softwaremill.quicklens._
 
 object EnumTestData {
   enum P3(val a: String):
@@ -18,5 +20,9 @@ class ModifyEnumTest extends AnyFlatSpec with Matchers {
 
   it should "modify a field in an enum case" in {
     modify(p3)(_.a).using(duplicate) should be(p3dup)
+  }
+
+  it should "modify a field in an enum case with extension method" in {
+    p3.modify(_.a).using(duplicate) should be(p3dup)
   }
 }


### PR DESCRIPTION
Turns out that adding just:
```scala
import com.softwaremill.quicklens._
```
stopped importing the extension methods and instead an explicit import for `modifyPimp._` is required.
Fortunately, extension methods in Scala 3 can now be called like normal functions as well.

Also changed the package of one of the tests, so that bugs isomorphic to this can be spotted.