### PR TITLE
Relax type constraint for QuicklensMapAt

### DIFF
--- a/quicklens/src/main/scala-2.13+/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-2.13+/com.softwaremill.quicklens/package.scala
@@ -310,6 +310,9 @@ sealed trait LowPriorityImplicits {
 
   import quicklens._
 
+  /**
+    * `QuicklensEach` is in `LowPriorityImplicits` to not conflict with the `QuicklensMapAtFunctor` on `each` calls.
+    */
   implicit class QuicklensEach[F[_], T](t: F[T])(implicit f: QuicklensFunctor[F, T]) {
     @compileTimeOnly(canOnlyBeUsedInsideModify("each"))
     def each: T = sys.error("")

--- a/quicklens/src/main/scala-2.13+/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-2.13+/com.softwaremill.quicklens/package.scala
@@ -1,14 +1,16 @@
 package com.softwaremill
 
+import com.softwaremill.quicklens.{QuicklensMapAtFunctor, canOnlyBeUsedInsideModify}
+
 import scala.annotation.compileTimeOnly
 import scala.collection.Factory
 import scala.collection.SeqLike
 import scala.language.experimental.macros
 import scala.language.higherKinds
 
-package object quicklens {
+package object quicklens extends LowPriorityImplicits {
 
-  private def canOnlyBeUsedInsideModify(method: String) =
+  private[softwaremill] def canOnlyBeUsedInsideModify(method: String) =
     s"$method can only be used inside modify"
 
   /**
@@ -177,14 +179,6 @@ package object quicklens {
       PathLazyModify[T, V]((t, vv) => self.doModify(t, u => f2.doModify(u, vv)))
   }
 
-  implicit class QuicklensEach[F[_], T](t: F[T])(implicit f: QuicklensFunctor[F, T]) {
-    @compileTimeOnly(canOnlyBeUsedInsideModify("each"))
-    def each: T = sys.error("")
-
-    @compileTimeOnly(canOnlyBeUsedInsideModify("eachWhere"))
-    def eachWhere(p: T => Boolean): T = sys.error("")
-  }
-
   trait QuicklensFunctor[F[_], A] {
     def map(fa: F[A])(f: A => A): F[A]
     def each(fa: F[A])(f: A => A): F[A] = map(fa)(f)
@@ -239,8 +233,8 @@ package object quicklens {
     def index(fa: F[T], idx: Int)(f: T => T): F[T]
   }
 
-  implicit class QuicklensMapAt[M[KT, TT] <: Map[KT, TT], K, T](t: M[K, T])(
-      implicit f: QuicklensMapAtFunctor[M, K, T]
+  implicit class QuicklensMapAt[M[KT, TT], K, T](t: M[K, T])(
+    implicit f: QuicklensMapAtFunctor[M, K, T]
   ) {
     @compileTimeOnly(canOnlyBeUsedInsideModify("at"))
     def at(idx: K): T = sys.error("")
@@ -310,4 +304,17 @@ package object quicklens {
       override def eachLeft(e: Either[L, R])(f: (L) => L) = e.left.map(f)
       override def eachRight(e: Either[L, R])(f: (R) => R) = e.map(f)
     }
+}
+
+sealed trait LowPriorityImplicits {
+
+  import quicklens._
+
+  implicit class QuicklensEach[F[_], T](t: F[T])(implicit f: QuicklensFunctor[F, T]) {
+    @compileTimeOnly(canOnlyBeUsedInsideModify("each"))
+    def each: T = sys.error("")
+
+    @compileTimeOnly(canOnlyBeUsedInsideModify("eachWhere"))
+    def eachWhere(p: T => Boolean): T = sys.error("")
+  }
 }

--- a/quicklens/src/main/scala-2.13-/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-2.13-/com.softwaremill.quicklens/package.scala
@@ -315,6 +315,9 @@ sealed trait LowPriorityImplicits {
 
   import quicklens._
 
+  /**
+    * `QuicklensEach` is in `LowPriorityImplicits` to not conflict with the `QuicklensMapAtFunctor` on `each` calls.
+    */
   implicit class QuicklensEach[F[_], T](t: F[T])(implicit f: QuicklensFunctor[F, T]) {
     @compileTimeOnly(canOnlyBeUsedInsideModify("each"))
     def each: T = sys.error("")

--- a/quicklens/src/test/scala-2/com.softwaremill.quicklens/QuicklensMapAtFunctorTest.scala
+++ b/quicklens/src/test/scala-2/com.softwaremill.quicklens/QuicklensMapAtFunctorTest.scala
@@ -1,0 +1,28 @@
+package com.softwaremill.quicklens
+
+import com.softwaremill.quicklens.TestData._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class QuicklensMapAtFunctorTest extends AnyFlatSpec with Matchers {
+
+  "QuicklensMapAtFunctor" should "work for types which is not a subtype of Map" in {
+    case class MapLike[K, V](underlying: Map[K, V])
+
+    implicit def instance[K, T]: QuicklensMapAtFunctor[MapLike, K, T] = new QuicklensMapAtFunctor[MapLike, K, T] {
+      private val mapInstance: QuicklensMapAtFunctor[Map, K, T] =
+        implicitly[QuicklensMapAtFunctor[Map, K, T]]
+
+      def at(fa: MapLike[K, T], idx: K)(f: T => T): MapLike[K, T] =
+        MapLike(mapInstance.at(fa.underlying, idx)(f))
+      def atOrElse(fa: MapLike[K, T], idx: K, default: => T)(f: T => T): MapLike[K, T] =
+        MapLike(mapInstance.atOrElse(fa.underlying, idx, default)(f))
+      def index(fa: MapLike[K, T], idx: K)(f: T => T): MapLike[K, T] =
+        MapLike(mapInstance.index(fa.underlying, idx)(f))
+      def each(fa: MapLike[K, T])(f: T => T): MapLike[K, T] =
+        MapLike(mapInstance.each(fa.underlying)(f))
+    }
+
+    modify(MapLike(m1))(_.at("K1").a5.name).using(duplicate) should be(MapLike(m1dup))
+  }
+}


### PR DESCRIPTION
I relaxed a type constraint for `implicit class QuicklensMapAt`. Previously it works only on subtypes of the `Map` type. With this PR it will work for any type with the instance of `QuicklensMapAtFunctor` typeclass.

Real-world use-case: newtype wrapping `Map`. It may not have subtype relationships but could work like a `Map`. In my codebase, I have a custom `NonEmptyMap`, for example.

Relaxing type constraint leads to an implicit resolution ambiguity: compiler can't choose between `QuicklensFunctor` and `QuicklensMapAtFunctor` for `each` calls. To fix this I moved `implicit class QuicklensEach` into the `LowPriorityImplicits` trait.

Overall it is a safe change in terms of API. All old code will work without changes.