### PR TITLE
Fix supporting modifying `sealed abstract classes` in Scala 3

### DIFF
--- a/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
+++ b/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
@@ -118,11 +118,10 @@ object QuicklensMacros {
           case AppliedType(_, typeParams) => Apply(TypeApply(Select(obj, copy), typeParams.map(Inferred(_))), args)
           case _                          => Apply(Select(obj, copy), args)
         }
-      else if (objSymbol.flags.is(Flags.Sealed) && objSymbol.flags.is(Flags.Trait)) || objSymbol.flags.is(
-          Flags.Enum
-        )
+      else if objSymbol.flags.is(Flags.Enum) ||
+        (objSymbol.flags.is(Flags.Sealed) && (objSymbol.flags.is(Flags.Trait) || objSymbol.flags.is(Flags.Abstract)))
       then
-        // if the source is a sealed trait / enum, generating a if-then-else with a .copy for each child (implementing case class)
+        // if the source is a sealed trait / sealed abstract class / enum, generating a if-then-else with a .copy for each child (implementing case class)
         val cases = obj.tpe.typeSymbol.children.map { child =>
           val subtype = TypeIdent(child)
           val bind = Symbol.newBind(owner, "c", Flags.EmptyFlags, subtype.tpe)

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ModitySealedAbstractClass.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ModitySealedAbstractClass.scala
@@ -1,0 +1,13 @@
+package com.softwaremill.quicklens.test
+
+import com.softwaremill.quicklens.TestData._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import com.softwaremill.quicklens._
+
+class ModitySealedAbstractClass extends AnyFlatSpec with Matchers {
+  it should "Modify abstract class hierarchy" in {
+    invInt.modify(_.typ).setTo(Type("Long")) should be(invLong)
+  }
+}

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/TestData.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/TestData.scala
@@ -78,4 +78,15 @@ object TestData {
   val ms1 = collection.immutable.SortedMap("K1" -> A4(A5("d1")), "K2" -> A4(A5("d2")), "K3" -> A4(A5("d3")))
   val mh1 = collection.immutable.HashMap("K1" -> A4(A5("d1")), "K2" -> A4(A5("d2")), "K3" -> A4(A5("d3")))
   val ml1 = collection.immutable.ListMap("K1" -> A4(A5("d1")), "K2" -> A4(A5("d2")), "K3" -> A4(A5("d3")))
+
+  case class Type(name: String)
+  sealed abstract class Variance {
+    val typ: Type
+  }
+  case class Covariance(typ: Type) extends Variance
+  case class Contravariance(typ: Type) extends Variance
+  case class Invariance(typ: Type) extends Variance
+
+  val invInt: Variance = Invariance(Type("Int"))
+  val invLong: Variance = Invariance(Type("Long"))
 }


### PR DESCRIPTION
This PR allows for `sealed abstract class`es to be modified in Scala 3.

All children of `sealed abstract class`es are known at compile-time, just like the children of `sealed trait`s, so they should be supported as well. (They worked for Scala 2.13, there was just no test for it)

I tried adding this test for all Scala versions, but it seemed to fail for Scala 2.11 with:
```scala
[error] quicklens/quicklens/src/test/scala/com/softwaremill/quicklens/ModitySealedAbstractClass.scala:9:18: Could not find subclasses of sealed trait class Variance.
[error] You might need to ensure that it gets compiled before this invocation.
[error] See also: <https://issues.scala-lang.org/browse/SI-7046>.
[error]     invInt.modify(_.typ).setTo(Type("Long")) should be(invLong)
[error]                  ^
[error] knownDirectSubclasses of Variance observed before subclass Covariance registered
[error] knownDirectSubclasses of Variance observed before subclass Contravariance registered
[error] knownDirectSubclasses of Variance observed before subclass Invariance registered
[error] four errors found
```