### PR TITLE
Scala3 array - each / index

### DIFF
--- a/quicklens/src/main/scala-3/com/softwaremill/quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com/softwaremill/quicklens/package.scala
@@ -168,6 +168,18 @@ package object quicklens {
         if fa.isDefinedAt(idx) then fa.updated(idx, f(fa(idx))).asInstanceOf[S[A]] else fa
     }
 
+    given QuicklensIndexedFunctor[Array, Int] with {
+      def at[A](fa: Array[A], f: A => A, idx: Int): Array[A] =
+        implicit val aClassTag: ClassTag[A] = fa.elemTag.asInstanceOf[ClassTag[A]]
+        fa.updated(idx, f(fa(idx)))
+      def atOrElse[A](fa: Array[A], f: A => A, idx: Int, default: => A): Array[A] =
+        implicit val aClassTag: ClassTag[A] = fa.elemTag.asInstanceOf[ClassTag[A]]
+        fa.updated(idx, f(fa.applyOrElse(idx, Function.const(default))))
+      def index[A](fa: Array[A], f: A => A, idx: Int): Array[A] =
+        implicit val aClassTag: ClassTag[A] = fa.elemTag.asInstanceOf[ClassTag[A]]
+        if fa.isDefinedAt(idx) then fa.updated(idx, f(fa(idx))) else fa
+    }
+
     given [K, M <: ([V] =>> Map[K, V])]: QuicklensIndexedFunctor[M, K] with {
       def at[A](fa: M[A], f: A => A, idx: K): M[A] =
         fa.updated(idx, f(fa(idx))).asInstanceOf[M[A]]

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ModifyAllOptimizedTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ModifyAllOptimizedTest.scala
@@ -3,6 +3,7 @@ package com.softwaremill.quicklens
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
+import scala.reflect.ClassTag
 
 class ModifyAllOptimizedTest extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
   import ModifyAllOptimizedTest._
@@ -186,7 +187,7 @@ object ModifyAllOptimizedTest {
   }
 
   given QuicklensFunctor[Opt] with {
-    def map[A, B](fa: Opt[A], f: A => B): Opt[B] =
+    def map[A](fa: Opt[A], f: A => A): Opt[A] =
       Opt.eachCount = Opt.eachCount + 1
       fa match {
         case Nada => Nada

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyArrayIndexTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyArrayIndexTest.scala
@@ -1,0 +1,27 @@
+package com.softwaremill.quicklens
+
+import com.softwaremill.quicklens.TestData._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ModifyArrayIndexTest extends AnyFlatSpec with Matchers {
+
+  it should "modify a non-nested array with case class item" in {
+    modify(ar1)(_.index(2).a4.a5.name).using(duplicate) should be(l1at2dup)
+    modify(ar1)(_.index(2))
+      .using(a3 => modify(a3)(_.a4.a5.name).using(duplicate)) should be(l1at2dup)
+  }
+
+  it should "modify a nested array using index" in {
+    modify(arar1)(_.index(2).index(1).name).using(duplicate) should be(ll1at2at1dup)
+  }
+
+  it should "modify a nested array using index and each" in {
+    modify(arar1)(_.index(2).each.name).using(duplicate) should be(ll1at2eachdup)
+    modify(arar1)(_.each.index(1).name).using(duplicate) should be(ll1eachat1dup)
+  }
+
+  it should "not modify if given index does not exist" in {
+    modify(ar1)(_.index(10).a4.a5.name).using(duplicate) should be(l1)
+  }
+}

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/TestData.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/TestData.scala
@@ -70,6 +70,9 @@ object TestData {
   val is1 = l1.toIndexedSeq
   val iss1 = ss1.map(_.toIndexedSeq).toIndexedSeq
 
+  val ar1: Array[A3] = s1.toArray
+  val arar1: Array[Array[A5]] = ss1.map(_.toArray).toArray
+
   case class M2(m3: Map[String, A4])
 
   val m1 = Map("K1" -> A4(A5("d1")), "K2" -> A4(A5("d2")), "K3" -> A4(A5("d3")))


### PR DESCRIPTION
Similar to #91, Scala 3 is missing support for `Array` (which is not a proper `Seq`).

I have implemented `index`, but `each` is a bit harder, as `Array` needs a `ClassTag` for construction.