### PR TITLE
Tuple modification fails with Scala 3

### DIFF
--- a/quicklens/src/test/scala/com/softwaremill/quicklens/TupleModifyTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/TupleModifyTest.scala
@@ -1,0 +1,24 @@
+package com.softwaremill.quicklens
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class TupleModifyTest extends AnyFlatSpec with Matchers {
+  it should "modify tuples using setTo" in {
+    val tuple4 = (0, 1, 2, 3)
+    val modified = tuple4.modify(_._3).setTo(3)
+    modified shouldBe(0, 1, 3, 3)
+  }
+
+  it should "modify tuples using using" in {
+    val tuple4 = (0, 1, 2, 3)
+    val modified = tuple4.modify(_._3).using(_ + 1)
+    modified shouldBe(0, 1, 3, 3)
+  }
+
+  it should "modify tuples using multiple modify" in {
+    val tuple4 = (0, 1, 2, 3)
+    val modified = tuple4.modify(_._3).using(_ + 1).modify(_._4).using(_ + 1)
+    modified shouldBe (0, 1, 3, 4)
+  }
+}

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/TupleModifyTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/TupleModifyTest.scala
@@ -4,21 +4,26 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class TupleModifyTest extends AnyFlatSpec with Matchers {
-  it should "modify tuples using setTo" in {
-    val tuple4 = (0, 1, 2, 3)
-    val modified = tuple4.modify(_._3).setTo(3)
-    modified shouldBe(0, 1, 3, 3)
+  it should "modify case classes using setTo" in {
+    case class Pair(a: Int, b: Int)
+    val p = Pair(0, 1)
+    val modified = p.modify(_.b).setTo(2)
+    modified shouldBe Pair(0, 2)
   }
-
+  it should "modify tuples using setTo" in {
+    val tuple = (0, 1)
+    val modified = tuple.modify(_._2).setTo(2)
+    modified shouldBe ((0, 2))
+  }
   it should "modify tuples using using" in {
     val tuple4 = (0, 1, 2, 3)
     val modified = tuple4.modify(_._3).using(_ + 1)
-    modified shouldBe(0, 1, 3, 3)
+    modified shouldBe ((0, 1, 3, 3))
   }
 
   it should "modify tuples using multiple modify" in {
     val tuple4 = (0, 1, 2, 3)
     val modified = tuple4.modify(_._3).using(_ + 1).modify(_._4).using(_ + 1)
-    modified shouldBe (0, 1, 3, 4)
+    modified shouldBe ((0, 1, 3, 4))
   }
 }


### PR DESCRIPTION
I have added unit tests which demonstrate tuple modification fails with Scala 3.

The test itself is very simple and works fine with Scala 2:

```
    val tuple4 = (0, 1, 2, 3)
    val modified = tuple4.modify(_._3).setTo(3)
    modified shouldBe(0, 1, 3, 3)
```

The error is:

```text
Exception occurred while executing macro expansion.
java.util.NoSuchElementException: head of empty list
	at scala.collection.immutable.Nil$.head(List.scala:662)
	at scala.collection.immutable.Nil$.head(List.scala:661)
	at com.softwaremill.quicklens.QuicklensMacros$.termMethodByNameUnsafe$1(QuicklensMacros.scala:142)
	at com.softwaremill.quicklens.QuicklensMacros$.$anonfun$38$$anonfun$1(QuicklensMacros.scala:173)
	at scala.collection.immutable.Map$Map1.getOrElse(Map.scala:250)
	at com.softwaremill.quicklens.QuicklensMacros$.$anonfun$38(QuicklensMacros.scala:173)
	at com.softwaremill.quicklens.QuicklensMacros$.$anonfun$adapted$1(QuicklensMacros.scala:174)
	at scala.collection.immutable.Range.map(Range.scala:59)
	at com.softwaremill.quicklens.QuicklensMacros$.caseClassCopy$1(QuicklensMacros.scala:174)
```

I will try to learn more, or develop a fix, but I cannot promise when.