### PR TITLE
Modification via a type alias failing on Scala 3

### DIFF
--- a/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyAliasTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyAliasTest.scala
@@ -10,6 +10,13 @@ object ModifyAliasTest {
   case class State(x: Int)
 
   type S = State
+
+  sealed trait Expr {
+    def i: Int
+  }
+  case class ListInt(i: Int) extends Expr
+
+  type E = Expr
 }
 
 class ModifyAliasTest extends AnyFlatSpec with Matchers {

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyAliasTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyAliasTest.scala
@@ -1,0 +1,22 @@
+package com.softwaremill.quicklens
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import ModifyAliasTest._
+
+object ModifyAliasTest {
+
+  case class State(x: Int)
+
+  type S = State
+}
+
+class ModifyAliasTest extends AnyFlatSpec with Matchers {
+  it should "modify an object declared using type alias" in {
+    val s: S = State(0)
+    val modified = s.modify(_.x).setTo(1)
+
+    modified.x shouldBe 1
+  }
+}

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyAliasTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyAliasTest.scala
@@ -26,4 +26,11 @@ class ModifyAliasTest extends AnyFlatSpec with Matchers {
 
     modified.x shouldBe 1
   }
+
+  it should "modify a sealed hierarchy declared using type alias" in {
+    val s: E = ListInt(0)
+    val modified = s.modify(_.i).setTo(1)
+
+    modified.i shouldBe 1
+  }
 }


### PR DESCRIPTION
Another Scala 3 regression. Following code fails to compile:

```scala

  case class State(x: Int)

  type S = State

  val s: S = State(0)
  val modified = s.modify(_.x).setTo(1)

  modified.x shouldBe 1
```

The error is:

> Unsupported source object: must be a case class or sealed trait, but got: type S

I think hopefully I should be able to prepare a fix.
