### PR TITLE
Issue with this in presence of self alias

### DIFF
--- a/quicklens/src/test/scala/com/softwaremill/quicklens/ModifySelfThisTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/ModifySelfThisTest.scala
@@ -1,0 +1,24 @@
+package com.softwaremill.quicklens
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import ModifySelfThisTest._
+
+object ModifySelfThisTest {
+
+  case class State(x: Int) {self =>
+
+    def mod: State = this.modify(_.x).setTo(1)
+  }
+
+}
+
+class ModifySelfThisTest extends AnyFlatSpec with Matchers {
+  it should "modify an object even in presence of self alias" in {
+    val s = State(0)
+    val modified = s.mod
+
+    modified.x shouldBe 1
+  }
+}


### PR DESCRIPTION
When a self alias is declared for a class, `this.modify` cannot be compiled, instead it results in error:

> `Unsupported source object: must be a case class or sealed trait, but got: val <none>`

Code:

```scala
  case class State(x: Int) {self =>

    def mod: State = this.modify(_.x).setTo(1)
  }
```

This PR adds test demonstrating this issue.

It is quite likely the issue is closely related to #97