### PR TITLE
Fix interaction of eachWhere and closure

### DIFF
--- a/quicklens/src/main/scala-2/com/softwaremill/quicklens/QuicklensMacros.scala
+++ b/quicklens/src/main/scala-2/com/softwaremill/quicklens/QuicklensMacros.scala
@@ -251,7 +251,7 @@ object QuicklensMacros {
         case FunctorPathElement(functor, method, xargs @ _*) :: tail =>
           val newRootPathEl = TermName(c.freshName())
           // combine the selected path with variable args
-          val args = generateSelects(newRootPathEl, tail) :: xargs.toList
+          val args = generateSelects(newRootPathEl, tail) :: xargs.toList.map(c.untypecheck(_))
           val rootPathElParamTree = ValDef(Modifiers(), rootPathEl, TypeTree(), EmptyTree)
           val functorMap = q"$functor.$method(..$args)(($rootPathElParamTree) => $newVal)"
           generateCopies(newRootPathEl, tail, functorMap)

--- a/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
+++ b/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
@@ -287,7 +287,7 @@ object QuicklensMacros {
       )
       val closure = Closure(Ref(defdefSymbol), None)
       val block = Block(List(defdefStatements), closure)
-      Apply(fun, List(objTerm, block) ++ f.args)
+      Apply(fun, List(objTerm, block) ++ f.args.map(_.changeOwner(owner)))
 
     def accumulateToCopy(
         owner: Symbol,

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyEachWhereTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyEachWhereTest.scala
@@ -15,6 +15,33 @@ class ModifyEachWhereTest extends AnyFlatSpec with Matchers {
     x4.modify(_.x5.eachWhere(_ => false).name).using(duplicate) should be(x4)
   }
 
+  it should "modify be able to eachWhere a lambda" in {
+    val foo = true
+    x4.modify(_.x5.eachWhere(_ => foo).name).using(duplicate) should be(x4dup)
+    val bar = false
+    x1.modify(_.x2.x3.eachWhere(_ => bar).x4.x5.eachWhere(_ => bar).name).using(duplicate) should be(x1)
+  }
+
+  it should "modify be able to eachWhere a lambda 1" in {
+    val one = "1"
+    person
+      .modify(_.addresses.each.street.eachWhere(_.name.startsWith(one)).name)
+      .using(_.toUpperCase)
+  }
+
+  it should "allow referencing local variable" in {
+    val zmienna = "d"
+    modify(z1)(_.name.eachWhere(_.startsWith(zmienna))).using(duplicate) should be(z1dup)
+  }
+
+  it should "allow referencing local variable 1" in {
+    val lang2 = "hey"
+
+    Seq(Foo("asdf"))
+      .modify(_.eachWhere(_.field != lang2).field)
+      .setTo(lang2) should be (Seq(Foo("hey")))
+  }
+
   it should "not modify an optional case class field if it is none regardless of the condition" in {
     modify(x4none)(_.x5.eachWhere(_ => true).name).using(duplicate) should be(x4none)
     modify(x4none)(_.x5.eachWhere(_ => false).name).using(duplicate) should be(x4none)

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/TestData.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/TestData.scala
@@ -98,4 +98,15 @@ object TestData {
 
   val invInt: Variance = Invariance(Type("Int"))
   val invLong: Variance = Invariance(Type("Long"))
+
+  case class Street(name: String)
+  case class Address(street: Option[Street])
+  case class Person(addresses: List[Address])
+
+  val person = Person(List(
+    Address(Some(Street("1 Functional Rd."))),
+    Address(Some(Street("2 Imperative Dr.")))
+  ))
+
+  case class Foo(field: String)
 }


### PR DESCRIPTION
For Scala 2 untypecheck args to automatically rewrite owners of functions.
For Scala 3 change owners of args manually.

closes softwaremill#41
closes softwaremill#60
closes softwaremill#86