### PR TITLE
Extract focuses from nested `Inlined` trees when determining modification path in Scala 3 macro

### DIFF
--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/CustomModifyProxyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/CustomModifyProxyTest.scala
@@ -1,0 +1,22 @@
+package com.softwaremill.quicklens.test
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import com.softwaremill.quicklens.*
+
+class CustomModifyProxyTest extends AnyFlatSpec with Matchers {
+
+  it should "correctly modify a class using a custom modify proxy method" in {
+    case class State(foo: Int)
+
+    inline def set[A](state: State, inline path: State => A, value: A): State = {
+      modify(state)(path).setTo(value)
+    }
+
+    val state = State(100)
+    val res = set(state, _.foo, 200)
+    val expected = State(200)
+    res.shouldBe(expected)
+  }
+
+}


### PR DESCRIPTION

closes softwaremill#159