### PR TITLE
Enable `at` with a derived key in Scala 3

### DIFF
--- a/quicklens/src/main/scala-3/com/softwaremill/quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com/softwaremill/quicklens/package.scala
@@ -161,7 +161,7 @@ package object quicklens {
     }
   }
 
-  trait QuicklensIndexedFunctor[F[_], I] {
+  trait QuicklensIndexedFunctor[F[_], -I] {
     def at[A](fa: F[A], f: A => A, idx: I): F[A]
     def atOrElse[A](fa: F[A], f: A => A, idx: I, default: => A): F[A]
     def index[A](fa: F[A], f: A => A, idx: I): F[A]

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyMapAtTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyMapAtTest.scala
@@ -57,4 +57,12 @@ class ModifyMapAtTest extends AnyFlatSpec with Matchers {
       modify(m1)(_.at("K0").a5.name).using(duplicate)
     }
   }
+
+  it should "modify a map using at with a derived class" in {
+    class C
+    object D extends C
+    val m = Map[C, String](D -> "")
+    val expected = Map(D -> "x")
+    modify(m)(_.at(D)).setTo("x") should be(expected)
+  }
 }


### PR DESCRIPTION
Test and fix for #210.

The test does not pass without the fix.

The fix is surprisingly simple: allow contravariance on `QuicklensIndexedFunctor`. I cannot say I understand why it works, but it works and all tests pass.