### PR TITLE
Extension copy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ excludeLintKeys in Global ++= Set(ideSkipProject)
 val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
   organization := "com.softwaremill.quicklens",
   updateDocs := UpdateVersionInDocs(sLog.value, organization.value, version.value, List(file("README.md"))),
-  scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked"), // useful for debugging macros: "-Ycheck:all"
+  scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked"), // useful for debugging macros: "-Ycheck:all", "-Xcheck-macros"
   ideSkipProject := (scalaVersion.value != scalaIdeaVersion)
 )
 

--- a/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
+++ b/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
@@ -427,7 +427,6 @@ object QuicklensMacros {
     def mapToCopy(owner: Symbol, mod: Expr[A => A], objTerm: Term, pathTree: PathTree): Term = pathTree match {
       case PathTree.Empty =>
         val apply = termMethodByNameUnsafe(mod.asTerm, "apply")
-        // TODO: calling extension may be necessary here
         Apply(Select(mod.asTerm, apply), List(objTerm))
       case PathTree.Node(children) =>
         accumulateToCopy(owner, mod, objTerm, children)

--- a/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
+++ b/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
@@ -343,7 +343,7 @@ object QuicklensMacros {
                 callMethod(Ref(objCompanion), copy, argsWithObj)
               case None => report.errorAndAbort(noSuchMember(objSymbol.name, "copy"))
       } else
-        report.errorAndAbort(s"Unsupported source object: must be a case class or sealed trait, but got: $objSymbol of type ${objTpe.show} (${obj.show})")
+        report.errorAndAbort(s"Unsupported source object: must be a case class, sealed trait or class with copy method, but got: $objSymbol of type ${objTpe.show} (${obj.show})")
     }
 
     def applyFunctionDelegate(

--- a/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
+++ b/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
@@ -408,7 +408,7 @@ object QuicklensMacros {
         objTerm
 
       case (_: (PathSymbol.Field | PathSymbol.Extension), _) :: _ =>
-        val (fs, funs) = pathSymbols.partition((ps, _) => ps.isInstanceOf[PathSymbol.Field] || ps.isInstanceOf[PathSymbol.Extension])
+        val (fs, funs) = pathSymbols.span((ps, _) => ps.isInstanceOf[PathSymbol.Field] || ps.isInstanceOf[PathSymbol.Extension])
         val fields = fs.collect { case (p: (PathSymbol.Field | PathSymbol.Extension), trees) => p -> trees }
         val withCopiedFields: Term = caseClassCopy(owner, mod, objTerm, fields)
         accumulateToCopy(owner, mod, withCopiedFields, funs)

--- a/quicklens/src/main/scala-3/com/softwaremill/quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com/softwaremill/quicklens/package.scala
@@ -154,7 +154,7 @@ package object quicklens {
       def map[A](fa: M[A], f: A => A): M[A] = {
         val mapped = fa.view.mapValues(f)
         (fa match {
-          case sfa: SortedMap[K, A] => sfa.sortedMapFactory.from(mapped)(using sfa.ordering)
+          case sfa: SortedMap[K, A]@unchecked => sfa.sortedMapFactory.from(mapped)(using sfa.ordering)
           case _                    => mapped.to(fa.mapFactory)
         }).asInstanceOf[M[A]]
       }

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExplicitCopyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExplicitCopyTest.scala
@@ -34,7 +34,8 @@ class ExplicitCopyTest extends AnyFlatSpec with Matchers {
       def paths(paths: Paths): Docs = copy(paths = paths)
     }
     val docs = Docs()
-    docs.modify(_.paths.pathItems).using(m => m + ("a" -> PathItem()))
+    val r = docs.modify(_.paths.pathItems).using(m => m + ("a" -> PathItem()))
+    r.paths.pathItems should contain ("a" -> PathItem())
   }
 
   it should "modify a case class with an additional explicit copy" in {
@@ -43,7 +44,8 @@ class ExplicitCopyTest extends AnyFlatSpec with Matchers {
     }
 
     val f = Frozen("A", 0)
-    f.modify(_.state).setTo("B")
+    val r = f.modify(_.state).setTo("B")
+    r.state shouldEqual "B"
   }
 
   it should "modify a case class with an ambiguous additional explicit copy" in {
@@ -52,7 +54,8 @@ class ExplicitCopyTest extends AnyFlatSpec with Matchers {
     }
 
     val f = Frozen("A", 0)
-    f.modify(_.state).setTo("B")
+    val r = f.modify(_.state).setTo("B")
+    r.state shouldEqual "B"
   }
 
   it should "modify a class with two explicit copy methods" in {
@@ -62,7 +65,8 @@ class ExplicitCopyTest extends AnyFlatSpec with Matchers {
     }
 
     val f = new Frozen("A", 0)
-    f.modify(_.state).setTo("B")
+    val r = f.modify(_.state).setTo("B")
+    r.state shouldEqual "B"
   }
 
   it should "modify a case class with an ambiguous additional explicit copy and pick the synthetic one first" in {

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExplicitCopyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExplicitCopyTest.scala
@@ -82,6 +82,19 @@ class ExplicitCopyTest extends AnyFlatSpec with Matchers {
     accessed shouldEqual 0
   }
 
+  it should "not compile when modifying a field which is not present as a copy parameter" in {
+    """
+    case class Content(x: String)
+
+    class A(val c: Content) {
+      def copy(x: String = c.x): A = new A(Content(x))
+    }
+
+    val a = new A(Content("A"))
+    val am = a.modify(_.c).setTo(Content("B"))
+    """ shouldNot compile
+  }
+
   // TODO: Would be nice to be able to handle this case. Based on the types, it
   // is obvious, that the explicit copy should be picked, but I'm not sure if we
   // can get that information

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExplicitCopyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExplicitCopyTest.scala
@@ -1,4 +1,5 @@
 package com.softwaremill.quicklens
+package test
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -90,5 +91,4 @@ class ExplicitCopyTest extends AnyFlatSpec with Matchers {
   //   val f = Frozen("A", 0)
   //   f.modify(_.state).setTo('B')
   // }
-
 }

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
@@ -11,35 +11,73 @@ object ExtensionCopyTest {
 
   object Vec {
     def apply(x: Double, y: Double): Vec = V(x, y)
-  }
 
-  extension (v: Vec) {
-    def x: Double = v.x
-    def y: Double = v.y
-    def copy(x: Double = v.x, y: Double = v.y): Vec = V(x, y)
+    extension (v: Vec) {
+      def x: Double = v.x
+      def y: Double = v.y
+      def copy(x: Double = v.x, y: Double = v.y): Vec = V(x, y)
+    }
   }
 }
 
 class ExtensionCopyTest extends AnyFlatSpec with Matchers {
-  it should "modify a class with an extension copy method" in {
-    case class V(x: Double, y: Double)
-
-    class Vec(val v: V)
-
-    object Vec {
-      def apply(x: Double, y: Double): Vec = new Vec(V(x, y))
+  /*
+  it should "modify a simple class with an extension copy method" in {
+    class VecSimple(xp: Double, yp: Double) {
+      val xMember = xp
+      val yMember = yp
     }
 
-    extension (v: Vec) {
-      def x: Double = v.v.x
-      def y: Double = v.v.y
-      def copy(x: Double = v.x, y: Double = v.y): Vec = new Vec(V(x, y))
+    object VecSimple {
+      def apply(x: Double, y: Double): VecSimple = new VecSimple(x, y)
     }
-    val a = Vec(1, 2)
+
+    extension (v: VecSimple) {
+      def copy(x: Double = v.xMember, y: Double = v.yMember): VecSimple = new VecSimple(x, y)
+    }
+    val a = VecSimple(1, 2)
+    val b = a.modify(_.xMember).using(_ + 1)
+    println(b)
+  }
+  */
+
+  it should "modify a simple class with an extension copy method in companion" in {
+    class VecCompanion(xp: Double, yp: Double) {
+      val x = xp
+      val y = yp
+    }
+
+    object VecCompanion {
+      def apply(x: Double, y: Double): VecCompanion = new VecCompanion(x, y)
+      extension (v: VecCompanion) {
+        def copy(x: Double = v.x, y: Double = v.y): VecCompanion = new VecCompanion(x, y)
+      }
+    }
+
+    val a = VecCompanion(1, 2)
     val b = a.modify(_.x).using(_ + 1)
     println(b)
   }
+  /*
 
+  it should "modify a class with an extension copy method" in {
+    case class V(x: Double, y: Double)
+
+    class VecClass(val v: V)
+
+    object VecClass {
+      def apply(x: Double, y: Double): VecClass = new VecClass(V(x, y))
+    }
+
+    extension (v: VecClass) {
+      def x: Double = v.v.x
+      def y: Double = v.v.y
+      def copy(x: Double = v.x, y: Double = v.y): VecClass = new VecClass(V(x, y))
+    }
+    val a = VecClass(1, 2)
+    val b = a.modify(_.x).using(_ + 1)
+    println(b)
+  }
   it should "modify an opaque type with an extension copy method" in {
     import ExtensionCopyTest.*
 
@@ -47,4 +85,5 @@ class ExtensionCopyTest extends AnyFlatSpec with Matchers {
     val b = a.modify(_.x).using(_ + 1)
     println(b)
   }
+   */
 }

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
@@ -58,32 +58,32 @@ class ExtensionCopyTest extends AnyFlatSpec with Matchers {
     val b = a.modify(_.x).using(_ + 1)
     println(b)
   }
-  /*
-
-  it should "modify a class with an extension copy method" in {
+  it should "modify a class with extension methods in companion" in {
     case class V(x: Double, y: Double)
 
     class VecClass(val v: V)
 
     object VecClass {
       def apply(x: Double, y: Double): VecClass = new VecClass(V(x, y))
+
+      extension (v: VecClass) {
+        def x: Double = v.v.x
+        def y: Double = v.v.y
+        def copy(x: Double = v.x, y: Double = v.y): VecClass = new VecClass(V(x, y))
+      }
     }
 
-    extension (v: VecClass) {
-      def x: Double = v.v.x
-      def y: Double = v.v.y
-      def copy(x: Double = v.x, y: Double = v.y): VecClass = new VecClass(V(x, y))
-    }
     val a = VecClass(1, 2)
     val b = a.modify(_.x).using(_ + 1)
     println(b)
   }
-  it should "modify an opaque type with an extension copy method" in {
+  /*
+  it should "modify an opaque type with extension methods" in {
     import ExtensionCopyTest.*
 
     val a = Vec(1, 2)
     val b = a.modify(_.x).using(_ + 1)
     println(b)
   }
-   */
+  */
 }

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
@@ -5,17 +5,17 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 object ExtensionCopyTest {
-  case class V(x: Double, y: Double)
+  case class V(x: Double, y: Double, z: Double)
 
   opaque type Vec = V
 
   object Vec {
-    def apply(x: Double, y: Double): Vec = V(x, y)
+    def apply(x: Double, y: Double): Vec = V(x, y, 0)
 
     extension (v: Vec) {
       def x: Double = v.x
       def y: Double = v.y
-      def copy(x: Double = v.x, y: Double = v.y): Vec = V(x, y)
+      def copy(x: Double = v.x, y: Double = v.y): Vec = V(x, y, 0)
     }
   }
 }
@@ -55,11 +55,12 @@ class ExtensionCopyTest extends AnyFlatSpec with Matchers {
     }
 
     val a = VecCompanion(1, 2)
-    val b = a.modify(_.x).using(_ + 1)
-    println(b)
+    val b = a.modify(_.x).using(_ + 10)
+    assert(b.x == 11)
   }
+
   it should "modify a class with extension methods in companion" in {
-    case class V(x: Double, y: Double)
+    case class V(xm: Double, ym: Double)
 
     class VecClass(val v: V)
 
@@ -67,23 +68,22 @@ class ExtensionCopyTest extends AnyFlatSpec with Matchers {
       def apply(x: Double, y: Double): VecClass = new VecClass(V(x, y))
 
       extension (v: VecClass) {
-        def x: Double = v.v.x
-        def y: Double = v.v.y
+        def x: Double = v.v.xm
+        def y: Double = v.v.ym
         def copy(x: Double = v.x, y: Double = v.y): VecClass = new VecClass(V(x, y))
       }
     }
 
     val a = VecClass(1, 2)
-    val b = a.modify(_.x).using(_ + 1)
-    println(b)
+    val b = a.modify(_.x).using(_ + 10)
+    assert(b.x == 11)
   }
-  /*
+
   it should "modify an opaque type with extension methods" in {
     import ExtensionCopyTest.*
 
     val a = Vec(1, 2)
-    val b = a.modify(_.x).using(_ + 1)
-    println(b)
+    val b = a.modify(_.x).using(_ + 10)
+    assert(b.x == 11)
   }
-  */
 }

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
@@ -1,0 +1,50 @@
+package com.softwaremill.quicklens
+package test
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+object ExtensionCopyTest {
+  case class V(x: Double, y: Double)
+
+  opaque type Vec = V
+
+  object Vec {
+    def apply(x: Double, y: Double): Vec = V(x, y)
+  }
+
+  extension (v: Vec) {
+    def x: Double = v.x
+    def y: Double = v.y
+    def copy(x: Double = v.x, y: Double = v.y): Vec = V(x, y)
+  }
+}
+
+class ExtensionCopyTest extends AnyFlatSpec with Matchers {
+  it should "modify a class with an extension copy method" in {
+    case class V(x: Double, y: Double)
+
+    class Vec(val v: V)
+
+    object Vec {
+      def apply(x: Double, y: Double): Vec = new Vec(V(x, y))
+    }
+
+    extension (v: Vec) {
+      def x: Double = v.v.x
+      def y: Double = v.v.y
+      def copy(x: Double = v.x, y: Double = v.y): Vec = new Vec(V(x, y))
+    }
+    val a = Vec(1, 2)
+    val b = a.modify(_.x).using(_ + 1)
+    println(b)
+  }
+
+  it should "modify an opaque type with an extension copy method" in {
+    import ExtensionCopyTest.*
+
+    val a = Vec(1, 2)
+    val b = a.modify(_.x).using(_ + 1)
+    println(b)
+  }
+}

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
@@ -56,7 +56,7 @@ class ExtensionCopyTest extends AnyFlatSpec with Matchers {
 
     val a = VecCompanion(1, 2)
     val b = a.modify(_.x).using(_ + 10)
-    assert(b.x == 11)
+    b.x shouldEqual 11
   }
 
   it should "modify a class with extension methods in companion" in {
@@ -76,7 +76,7 @@ class ExtensionCopyTest extends AnyFlatSpec with Matchers {
 
     val a = VecClass(1, 2)
     val b = a.modify(_.x).using(_ + 10)
-    assert(b.x == 11)
+    b.x shouldEqual 11
   }
 
   it should "modify an opaque type with extension methods" in {
@@ -84,6 +84,6 @@ class ExtensionCopyTest extends AnyFlatSpec with Matchers {
 
     val a = Vec(1, 2)
     val b = a.modify(_.x).using(_ + 10)
-    assert(b.x == 11)
+    b.x shouldEqual 11
   }
 }

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
@@ -21,8 +21,9 @@ object ExtensionCopyTest {
 }
 
 class ExtensionCopyTest extends AnyFlatSpec with Matchers {
-  /*
   it should "modify a simple class with an extension copy method" in {
+    // this test does compile at the moment, because we search extensions in companions only
+    /*
     class VecSimple(xp: Double, yp: Double) {
       val xMember = xp
       val yMember = yp
@@ -36,10 +37,10 @@ class ExtensionCopyTest extends AnyFlatSpec with Matchers {
       def copy(x: Double = v.xMember, y: Double = v.yMember): VecSimple = new VecSimple(x, y)
     }
     val a = VecSimple(1, 2)
-    val b = a.modify(_.xMember).using(_ + 1)
-    println(b)
+    val b = a.modify(_.xMember).using(_ + 10)
+    b.xMember shouldEqual 11
+    */
   }
-  */
 
   it should "modify a simple class with an extension copy method in companion" in {
     class VecCompanion(xp: Double, yp: Double) {


### PR DESCRIPTION
Started work on #234 by creating target test.

At the moment the test is failing with:

> Unsupported path element. Path must have shape: _.field1.field2.each. field3.(...), got: ((_$1: Vec) => x(_$1))

I am not sure how far I will get, I never tried to access extensions from macros, but hopefully it should be possible.
