### PR TITLE
Make compilable with -Xcheck-macros

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ excludeLintKeys in Global ++= Set(ideSkipProject)
 val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
   organization := "com.softwaremill.quicklens",
   updateDocs := UpdateVersionInDocs(sLog.value, organization.value, version.value, List(file("README.md"))),
-  scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked"), // useful for debugging macros: "-Ycheck:all", "-Xcheck-macros"
+  scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xcheck-macros"),
   ideSkipProject := (scalaVersion.value != scalaIdeaVersion)
 )
 


### PR DESCRIPTION
At this moment the PR only enables -Xcheck-macros. The library does not compile, there are 5 errors.

Once there is:

```
Malformed tree was found while expanding macro with -Xcheck-macros.
               |The tree does not conform to the compiler's tree invariants.
               |
               |Macro was:
               |scala.quoted.runtime.Expr.splice[com.softwaremill.quicklens.PathModify[com.softwaremill.quicklens.ModifyAndTypeTest.B & com.softwaremill.quicklens.ModifyAndTypeTest.A1, scala.Int]](((evidence$1: scala.quoted.Quotes) ?=> com.softwaremill.quicklens.QuicklensMacros.toPathModifyFromFocus[com.softwaremill.quicklens.ModifyAndTypeTest.B & com.softwaremill.quicklens.ModifyAndTypeTest.A1, scala.Int](scala.quoted.runtime.Expr.quote[com.softwaremill.quicklens.ModifyAndTypeTest.B & com.softwaremill.quicklens.ModifyAndTypeTest.A1](ab).apply(using evidence$1), scala.quoted.runtime.Expr.quote[scala.Function1[com.softwaremill.quicklens.ModifyAndTypeTest.B & com.softwaremill.quicklens.ModifyAndTypeTest.A1, scala.Int]](((_$3: com.softwaremill.quicklens.ModifyAndTypeTest.B & com.softwaremill.quicklens.ModifyAndTypeTest.A1) => _$3.a)).apply(using evidence$1))(scala.quoted.Type.of[com.softwaremill.quicklens.ModifyAndTypeTest.B & com.softwaremill.quicklens.ModifyAndTypeTest.A1](evidence$1), scala.quoted.Type.of[scala.Int](evidence$1), evidence$1)))
               |
               |The macro returned:
               |com.softwaremill.quicklens.PathModify.apply[com.softwaremill.quicklens.ModifyAndTypeTest.B & com.softwaremill.quicklens.ModifyAndTypeTest.A1, scala.Int](ab, ((x: scala.Function1[scala.Int, scala.Int]) => (ab.copy(a = x.apply(ab.a)): com.softwaremill.quicklens.ModifyAndTypeTest.B & com.softwaremill.quicklens.ModifyAndTypeTest.A1)))
               |
               |Error:
               |assertion failed: Found:    com.softwaremill.quicklens.ModifyAndTypeTest.A1
Required: com.softwaremill.quicklens.ModifyAndTypeTest.B &
  com.softwaremill.quicklens.ModifyAndTypeTest.A1
found: class A1 in object ModifyAndTypeTest with class A1, flags = case <noinits> <touched>, underlying = com.softwaremill.quicklens.ModifyAndTypeTest.A1, Object with Product with Serializable {...}
expected: ??
tree = ab.copy(a = x.apply(ab.a))
```

And four times there are variants of:

```scala
Exception occurred while executing macro expansion.
java.lang.AssertionError: Reference to a method must be eta-expanded before it is used as an expression: com.softwaremill.quicklens.TestData.aPoly.copy$default$2
	at scala.collection.immutable.List.foreach(List.scala:334)
	at scala.quoted.runtime.impl.QuotesImpl$reflect$.scala$quoted$runtime$impl$QuotesImpl$reflect$$$xCheckMacroValidExprs(QuotesImpl.scala:3111)
	at scala.quoted.runtime.impl.QuotesImpl$reflect$Apply$.apply(QuotesImpl.scala:645)
	at scala.quoted.runtime.impl.QuotesImpl$reflect$Apply$.apply(QuotesImpl.scala:643)
	at com.softwaremill.quicklens.QuicklensMacros$.callMethod$1$$anonfun$3(QuicklensMacros.scala:266)
	at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183)
	at scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:179)
	at scala.collection.immutable.List.foldLeft(List.scala:79)
	at com.softwaremill.quicklens.QuicklensMacros$.callMethod$1(QuicklensMacros.scala:266)
...
    aPoly.modify(_.poly).using(duplicate) should be(aPolyDup)

```

Hopefully solving those should not be very difficult?