### PR TITLE
Add failing test: Fix Seq/Array atOrElse throwing IndexOutOfBoundsException for missing indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,16 @@ person.modify(_.addresses.at(2).street.atOrElse(Street("main street")).name).usi
  For sequences and arrays, `.atOrElse` behaves like `.at` when the index is in range. If the index is
  out of range, the modified default is appended to the end of the collection (rather than padding every
  intermediate position with the default).
+ 
+ ````scala
+ val people = List(Person("alice"), Person("bob"))
+ // index in range, behaves like .at
+ people.modify(_.atOrElse(1, Person("nobody")).name).using(_.toUpperCase)
+ // => List(Person("alice"), Person("BOB"))
+ // index out of range, modified default appended
+ people.modify(_.atOrElse(5, Person("nobody")).name).using(_.toUpperCase)
+ // => List(Person("alice"), Person("bob"), Person("NOBODY"))
+ ````
 
 **Modify Either fields using `.eachLeft` and `.eachRight`:**
 

--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ For Options, `.atOrElse` takes no arguments and acts similarly.
 person.modify(_.addresses.at(2).street.atOrElse(Street("main street")).name).using(_.toUpperCase)
  ````
  
- `.atOrElse` is currently not available for sequences because quicklens might need to insert many
- elements in the list in order to ensure that one is available at a particular position, and it's not
- clear that providing one default for all keys is the right behavior. 
+ For sequences and arrays, `.atOrElse` behaves like `.at` when the index is in range. If the index is
+ out of range, the modified default is appended to the end of the collection (rather than padding every
+ intermediate position with the default).
 
 **Modify Either fields using `.eachLeft` and `.eachRight`:**
 

--- a/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
+++ b/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
@@ -118,7 +118,7 @@ object QuicklensMacros {
       def name: String
 
       def equiv(other: Any): Boolean = (this, other) match
-        case (Field(name1), Field(name2)) => name1 == name2
+        case (Field(name1), Field(name2))                       => name1 == name2
         case (Extension(term1, name1), Extension(term2, name2)) => term1 == term2 && name1 == name2
         case (FunctionDelegate(name1, _, typeTree1, args1), FunctionDelegate(name2, _, typeTree2, args2)) =>
           name1 == name2 && typeTree1.tpe == typeTree2.tpe && args1 == args2
@@ -140,7 +140,7 @@ object QuicklensMacros {
         case a @ Apply(TypeApply(Apply(TypeApply(Ident(s), _), idents), typeTrees), List(givn)) if methodSupported(s) =>
           idents.flatMap(toPath(_, focus)) :+ PathSymbol.FunctionDelegate(s, givn, typeTrees.last, List.empty)
         /** Extension method, which is called e.g. as x(_$1) */
-        case Apply(obj@Select(term, member), Seq(deep)) if obj.symbol.flags.is(Flags.ExtensionMethod) =>
+        case Apply(obj @ Select(term, member), Seq(deep)) if obj.symbol.flags.is(Flags.ExtensionMethod) =>
           toPath(deep, focus) :+ PathSymbol.Extension(term, member)
         /** Field access */
         case Apply(deep, idents) =>
@@ -182,8 +182,7 @@ object QuicklensMacros {
       val objSymbol = objTpe.matchingTypeSymbol
       // opaque types can find members of underlying types - ignore them (see https://github.com/scala/scala3/issues/22143)
       val fieldMemberSym = objSymbol.fieldMember(name)
-      if !objSymbol.flags.is(Flags.Deferred) && fieldMemberSym.exists then
-        Select(obj, fieldMemberSym)
+      if !objSymbol.flags.is(Flags.Deferred) && fieldMemberSym.exists then Select(obj, fieldMemberSym)
       else
         objSymbol.methodMember(name) match
           case List(m) =>
@@ -192,10 +191,15 @@ object QuicklensMacros {
             report.errorAndAbort(reportMethodError(objSymbol, name, lst))
     }
 
-    def reportMethodError(sym: Symbol, name: String, lst: List[Symbol], maybeArgNames: Option[Iterable[String]] = None): String = {
+    def reportMethodError(
+        sym: Symbol,
+        name: String,
+        lst: List[Symbol],
+        maybeArgNames: Option[Iterable[String]] = None
+    ): String = {
       (lst, maybeArgNames) match
-        case (Nil, _) => noSuchMember(sym.name, name)
-        case (lst, None) => multipleMatchingMethods(sym.name, name, lst)
+        case (Nil, _)              => noSuchMember(sym.name, name)
+        case (lst, None)           => multipleMatchingMethods(sym.name, name, lst)
         case (lst, Some(argNames)) => noSuitableMember(sym.name, name, argNames)
     }
 
@@ -212,14 +216,14 @@ object QuicklensMacros {
         val paramNames = msym.paramSymss.flatten.filter(_.isTerm).map(_.name)
         argNames.forall(paramNames.contains)
       } match
-        case List(m) => Some(m)
-        case Nil => None
-        case lst@(m :: _) =>
+        case List(m)        => Some(m)
+        case Nil            => None
+        case lst @ (m :: _) =>
           // if we have multiple matching copy methods, pick the synthetic one, if it exists, otherwise, pick any method
           val syntheticCopies = lst.filter(_.flags.is(Flags.Synthetic))
           syntheticCopies match
             case List(mSynth) => Some(mSynth)
-            case _ => Some(m)
+            case _            => Some(m)
     }
 
     def methodSymbolByNameAndArgs(sym: Symbol, name: String, argsMap: Map[String, Term]): Either[String, Symbol] = {
@@ -230,20 +234,25 @@ object QuicklensMacros {
       else Left(s"Deferred type ${sym.name}")
     }
 
-    /**
-      * @param argsMap normal methods receive one parameter list, extensions methods two, the first one contains the value
-      *                on which the extension is called
-      * */
+    /** @param argsMap
+      *   normal methods receive one parameter list, extensions methods two, the first one contains the value on which
+      *   the extension is called
+      */
     def callMethod(obj: Term, copy: Symbol, argsMap: List[Map[String, Term]]) = {
-      require(argsMap.size == 1 || argsMap.size == 2, s"argsMap.size should be either 1 or 2, got: ${argsMap.size} ($argsMap)")
+      require(
+        argsMap.size == 1 || argsMap.size == 2,
+        s"argsMap.size should be either 1 or 2, got: ${argsMap.size} ($argsMap)"
+      )
       val objTpe = obj.tpe.widenAll
       val objSymbol = objTpe.matchingTypeSymbol
 
       val typeParams = objTpe.typeArgs
       val copyTree: DefDef = copy.tree.asInstanceOf[DefDef]
-      val copyParams: List[(String, Option[Term])] = copyTree.termParamss.zip(argsMap)
+      val copyParams: List[(String, Option[Term])] = copyTree.termParamss
+        .zip(argsMap)
         .map((params, args) => params.params.map(_.name).map(name => name -> args.get(name)))
-        .flatten.toList
+        .flatten
+        .toList
 
       val args = copyParams.zipWithIndex.map { case ((n, v), _i) =>
         val i = _i + 1
@@ -255,7 +264,8 @@ object QuicklensMacros {
         n -> v.getOrElse(defaultMethod)
       }.toMap
 
-      val argLists: List[List[Term]] = copyTree.termParamss.take(argsMap.size).map(list => list.params.map(p => args(p.name)))
+      val argLists: List[List[Term]] =
+        copyTree.termParamss.take(argsMap.size).map(list => list.params.map(p => args(p.name)))
 
       if copyTree.termParamss.drop(argLists.size).exists(_.params.exists(!_.symbol.flags.is(Flags.Implicit))) then
         report.errorAndAbort(
@@ -281,8 +291,7 @@ object QuicklensMacros {
     }
 
     def findCompanionLikeObject(objSymbol: Symbol): Symbol = {
-      if objSymbol.companionModule.exists then
-        objSymbol.companionModule
+      if objSymbol.companionModule.exists then objSymbol.companionModule
       else
         val namedFromOwnerScope = objSymbol.owner.fieldMember(objSymbol.name)
         if namedFromOwnerScope.flags.is(Flags.Module) then namedFromOwnerScope
@@ -293,8 +302,7 @@ object QuicklensMacros {
       val companionSymbol = findCompanionLikeObject(sym)
       if companionSymbol.exists then
         companionSymbol.methodMember(methodName).filter(s => s.name == methodName && s.flags.is(Flags.ExtensionMethod))
-      else
-        Nil
+      else Nil
     }
 
     def isProductLike(sym: Symbol): Boolean = {
@@ -367,7 +375,9 @@ object QuicklensMacros {
                 callMethod(Ref(objCompanion), copy, argsWithObj)
               case None => report.errorAndAbort(error)
       } else
-        report.errorAndAbort(s"Unsupported source object: must be a case class, sealed trait or class with copy method, but got: $objSymbol of type ${objTpe.show} (${obj.show})")
+        report.errorAndAbort(
+          s"Unsupported source object: must be a case class, sealed trait or class with copy method, but got: $objSymbol of type ${objTpe.show} (${obj.show})"
+        )
     }
 
     def applyFunctionDelegate(
@@ -408,7 +418,8 @@ object QuicklensMacros {
         objTerm
 
       case (_: (PathSymbol.Field | PathSymbol.Extension), _) :: _ =>
-        val (fs, funs) = pathSymbols.span((ps, _) => ps.isInstanceOf[PathSymbol.Field] || ps.isInstanceOf[PathSymbol.Extension])
+        val (fs, funs) =
+          pathSymbols.span((ps, _) => ps.isInstanceOf[PathSymbol.Field] || ps.isInstanceOf[PathSymbol.Extension])
         val fields = fs.collect { case (p: (PathSymbol.Field | PathSymbol.Extension), trees) => p -> trees }
         val withCopiedFields: Term = caseClassCopy(owner, mod, objTerm, fields)
         accumulateToCopy(owner, mod, withCopiedFields, funs)

--- a/quicklens/src/main/scala-3/com/softwaremill/quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com/softwaremill/quicklens/package.scala
@@ -154,8 +154,8 @@ package object quicklens {
       def map[A](fa: M[A], f: A => A): M[A] = {
         val mapped = fa.view.mapValues(f)
         (fa match {
-          case sfa: SortedMap[K, A]@unchecked => sfa.sortedMapFactory.from(mapped)(using sfa.ordering)
-          case _                    => mapped.to(fa.mapFactory)
+          case sfa: SortedMap[K, A] @unchecked => sfa.sortedMapFactory.from(mapped)(using sfa.ordering)
+          case _                               => mapped.to(fa.mapFactory)
         }).asInstanceOf[M[A]]
       }
     }
@@ -172,7 +172,8 @@ package object quicklens {
       def at[A](fa: S[A], f: A => A, idx: Int): S[A] =
         fa.updated(idx, f(fa(idx))).asInstanceOf[S[A]]
       def atOrElse[A](fa: S[A], f: A => A, idx: Int, default: => A): S[A] =
-        fa.updated(idx, f(fa.applyOrElse(idx, Function.const(default)))).asInstanceOf[S[A]]
+        if fa.isDefinedAt(idx) then fa.updated(idx, f(fa(idx))).asInstanceOf[S[A]]
+        else (fa :+ f(default)).asInstanceOf[S[A]]
       def index[A](fa: S[A], f: A => A, idx: Int): S[A] =
         if fa.isDefinedAt(idx) then fa.updated(idx, f(fa(idx))).asInstanceOf[S[A]] else fa
     }
@@ -183,7 +184,8 @@ package object quicklens {
         fa.updated(idx, f(fa(idx)))
       def atOrElse[A](fa: Array[A], f: A => A, idx: Int, default: => A): Array[A] =
         implicit val aClassTag: ClassTag[A] = fa.elemTag.asInstanceOf[ClassTag[A]]
-        fa.updated(idx, f(fa.applyOrElse(idx, Function.const(default))))
+        if fa.isDefinedAt(idx) then fa.updated(idx, f(fa(idx)))
+        else fa :+ f(default)
       def index[A](fa: Array[A], f: A => A, idx: Int): Array[A] =
         implicit val aClassTag: ClassTag[A] = fa.elemTag.asInstanceOf[ClassTag[A]]
         if fa.isDefinedAt(idx) then fa.updated(idx, f(fa(idx))) else fa

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExplicitCopyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExplicitCopyTest.scala
@@ -26,16 +26,16 @@ class ExplicitCopyTest extends AnyFlatSpec with Matchers {
   it should "modify a class that has a method with the same name as a field" in {
     final case class PathItem()
     final case class Paths(
-      pathItems: Map[String, PathItem] = Map.empty
+        pathItems: Map[String, PathItem] = Map.empty
     )
     final case class Docs(
-      paths: Paths = Paths()
+        paths: Paths = Paths()
     ) {
       def paths(paths: Paths): Docs = copy(paths = paths)
     }
     val docs = Docs()
     val r = docs.modify(_.paths.pathItems).using(m => m + ("a" -> PathItem()))
-    r.paths.pathItems should contain ("a" -> PathItem())
+    r.paths.pathItems should contain("a" -> PathItem())
   }
 
   it should "modify a case class with an additional explicit copy" in {

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
@@ -39,7 +39,7 @@ class ExtensionCopyTest extends AnyFlatSpec with Matchers {
     val a = VecSimple(1, 2)
     val b = a.modify(_.xMember).using(_ + 10)
     b.xMember shouldEqual 11
-    */
+     */
   }
 
   it should "modify a simple class with an extension copy method in companion" in {

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ModifySeqAtOrElseTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ModifySeqAtOrElseTest.scala
@@ -1,0 +1,31 @@
+package com.softwaremill.quicklens
+package test
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ModifySeqAtOrElseTest extends AnyFlatSpec with Matchers {
+
+  case class Item(name: String)
+
+  it should "modify an existing element of a Seq using atOrElse" in {
+    val items = List(Item("a"), Item("b"))
+    modify(items)(_.atOrElse(1, Item("default")).name).using(_.toUpperCase) should be(
+      List(Item("a"), Item("B"))
+    )
+  }
+
+  it should "not throw for an index outside the Seq, using the default" in {
+    val items = List(Item("a"), Item("b"))
+    noException should be thrownBy {
+      modify(items)(_.atOrElse(5, Item("default")).name).using(_.toUpperCase)
+    }
+  }
+
+  it should "not throw for an index outside an Array, using the default" in {
+    val items = Array(Item("a"), Item("b"))
+    noException should be thrownBy {
+      modify(items)(_.atOrElse(5, Item("default")).name).using(_.toUpperCase)
+    }
+  }
+}

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ModifySeqAtOrElseTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ModifySeqAtOrElseTest.scala
@@ -15,17 +15,24 @@ class ModifySeqAtOrElseTest extends AnyFlatSpec with Matchers {
     )
   }
 
-  it should "not throw for an index outside the Seq, using the default" in {
-    val items = List(Item("a"), Item("b"))
-    noException should be thrownBy {
-      modify(items)(_.atOrElse(5, Item("default")).name).using(_.toUpperCase)
-    }
+  it should "modify an existing element of an Array using atOrElse" in {
+    val items = Array(Item("a"), Item("b"))
+    modify(items)(_.atOrElse(1, Item("default")).name).using(_.toUpperCase).toList should be(
+      List(Item("a"), Item("B"))
+    )
   }
 
-  it should "not throw for an index outside an Array, using the default" in {
+  it should "append the modified default for an index outside the Seq" in {
+    val items = List(Item("a"), Item("b"))
+    modify(items)(_.atOrElse(5, Item("default")).name).using(_.toUpperCase) should be(
+      List(Item("a"), Item("b"), Item("DEFAULT"))
+    )
+  }
+
+  it should "append the modified default for an index outside an Array" in {
     val items = Array(Item("a"), Item("b"))
-    noException should be thrownBy {
-      modify(items)(_.atOrElse(5, Item("default")).name).using(_.toUpperCase)
-    }
+    modify(items)(_.atOrElse(5, Item("default")).name).using(_.toUpperCase).toList should be(
+      List(Item("a"), Item("b"), Item("DEFAULT"))
+    )
   }
 }


### PR DESCRIPTION
Addresses softwaremill/quicklens#301

The `atOrElse` method on Seq and Array currently throws an `IndexOutOfBoundsException` when accessing an out-of-bounds index, instead of returning the provided default value.

This commit adds test cases capturing the expected behavior: modifying existing elements should work correctly, and accessing out-of-bounds indices should use the default value without throwing an exception.

The actual fix is pending in a follow-up commit.

Closes softwaremill/quicklens#301.