### PR TITLE
Add failing test for Seq/Array atOrElse IndexOutOfBoundsException (issue #301)

### DIFF
--- a/quicklens/src/test/scala/com/softwaremill/quicklens/ModifySeqAtOrElseTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/ModifySeqAtOrElseTest.scala
@@ -1,0 +1,19 @@
+package com.softwaremill.quicklens
+
+import com.softwaremill.quicklens.TestData._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ModifySeqAtOrElseTest extends AnyFlatSpec with Matchers {
+
+  it should "modify an existing element of a list using atOrElse" in {
+    modify(l1)(_.atOrElse(2, A3(A4(A5("d4")))).a4.a5.name).using(duplicate) should be(l1at2dup)
+  }
+
+  it should "not throw for a missing index, using the default instead" in {
+    val items = List(A5("a"), A5("b"))
+    noException should be thrownBy {
+      modify(items)(_.atOrElse(5, A5("default")).name).using(duplicate)
+    }
+  }
+}


### PR DESCRIPTION
Addresses softwaremill/quicklens#301.

The `atOrElse` operator on Seq/Array currently throws `IndexOutOfBoundsException` when accessing a missing index instead of using the provided default value. This test demonstrates the expected behavior.

The test includes two cases: modifying an existing element at a valid index (current working behavior), and accessing a missing index with `atOrElse` without throwing (expected behavior that currently fails).

The actual fix implementation is pending.

Closes softwaremill/quicklens#301.