### PR TITLE
Add failing test: Fix Seq/Array atOrElse throwing IndexOutOfBoundsException for missing indices

### DIFF
--- a/quicklens/src/test/scala/com/softwaremill/quicklens/ModifySeqAtOrElseTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/ModifySeqAtOrElseTest.scala
@@ -1,0 +1,18 @@
+package com.softwaremill.quicklens
+
+import com.softwaremill.quicklens.TestData._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ModifySeqAtOrElseTest extends AnyFlatSpec with Matchers {
+
+  it should "modify an existing index of a seq using atOrElse" in {
+    modify(s1)(_.atOrElse(2, A3(A4(A5("d3")))).a4.a5.name).using(duplicate) should be(l1at2dup)
+  }
+
+  it should "use the default when the index is out of bounds instead of throwing" in {
+    modify(s1)(_.atOrElse(10, A3(A4(A5("d5")))).a4.a5.name).using(duplicate) should be(
+      l1 :+ A3(A4(A5("d5d5")))
+    )
+  }
+}


### PR DESCRIPTION
Addresses softwaremill/quicklens#301.

Adds a test case that demonstrates the bug where `atOrElse` throws an `IndexOutOfBoundsException` when accessing an out-of-bounds index, instead of using the provided default value.

The test covers two scenarios:
1. Modifying an existing index in a sequence (baseline case)
2. Using `atOrElse` with an out-of-bounds index, which should apply the default and then continue the modification chain

This test is currently failing. The actual fix to make `atOrElse` return the default for missing indices is pending.

Closes softwaremill/quicklens#301.