### PR TITLE
Implement Seq/Array atOrElse with append-on-missing-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,8 @@ For Options, `.atOrElse` takes no arguments and acts similarly.
 person.modify(_.addresses.at(2).street.atOrElse(Street("main street")).name).using(_.toUpperCase)
  ````
  
- `.atOrElse` is currently not available for sequences because quicklens might need to insert many
- elements in the list in order to ensure that one is available at a particular position, and it's not
- clear that providing one default for all keys is the right behavior. 
+ For sequences (and arrays), if an element exists at the given index, `.atOrElse` behaves the same as
+ `.at`. If the index is out of bounds, the modified default is appended once at the end of the sequence.
 
 **Modify Either fields using `.eachLeft` and `.eachRight`:**
 

--- a/quicklens/src/main/scala-2.13+/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-2.13+/com.softwaremill.quicklens/package.scala
@@ -211,12 +211,15 @@ package object quicklens extends LowPriorityImplicits {
   implicit class QuicklensAt[F[_], T](t: F[T])(implicit f: QuicklensAtFunctor[F, T]) {
     @compileTimeOnly(canOnlyBeUsedInsideModify("at"))
     def at(idx: Int): T = sys.error("")
+    @compileTimeOnly(canOnlyBeUsedInsideModify("atOrElse"))
+    def atOrElse(idx: Int, default: => T): T = sys.error("")
     @compileTimeOnly(canOnlyBeUsedInsideModify("index"))
     def index(idx: Int): T = sys.error("")
   }
 
   trait QuicklensAtFunctor[F[_], T] {
     def at(fa: F[T], idx: Int)(f: T => T): F[T]
+    def atOrElse(fa: F[T], idx: Int, default: => T)(f: T => T): F[T]
     def index(fa: F[T], idx: Int)(f: T => T): F[T]
   }
 
@@ -264,6 +267,9 @@ package object quicklens extends LowPriorityImplicits {
     new QuicklensAtFunctor[F, T] {
       override def at(fa: F[T], idx: Int)(f: T => T): F[T] =
         fa.updated(idx, f(fa(idx))).to(fac)
+      override def atOrElse(fa: F[T], idx: Int, default: => T)(f: T => T): F[T] =
+        if (idx >= 0 && idx < fa.size) fa.updated(idx, f(fa(idx))).to(fac)
+        else (fa :+ f(default)).to(fac)
       override def index(fa: F[T], idx: Int)(f: T => T): F[T] =
         if (idx < fa.size) fa.updated(idx, f(fa(idx))).to(fac) else fa
     }

--- a/quicklens/src/main/scala-2.13+/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-2.13+/com.softwaremill.quicklens/package.scala
@@ -268,7 +268,7 @@ package object quicklens extends LowPriorityImplicits {
       override def at(fa: F[T], idx: Int)(f: T => T): F[T] =
         fa.updated(idx, f(fa(idx))).to(fac)
       override def atOrElse(fa: F[T], idx: Int, default: => T)(f: T => T): F[T] =
-        if (idx >= 0 && idx < fa.size) fa.updated(idx, f(fa(idx))).to(fac)
+        if (fa.isDefinedAt(idx)) fa.updated(idx, f(fa(idx))).to(fac)
         else (fa :+ f(default)).to(fac)
       override def index(fa: F[T], idx: Int)(f: T => T): F[T] =
         if (idx < fa.size) fa.updated(idx, f(fa(idx))).to(fac) else fa

--- a/quicklens/src/main/scala-2.13-/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-2.13-/com.softwaremill.quicklens/package.scala
@@ -213,12 +213,16 @@ package object quicklens extends LowPriorityImplicits {
     @compileTimeOnly(canOnlyBeUsedInsideModify("at"))
     def at(idx: Int): T = sys.error("")
 
+    @compileTimeOnly(canOnlyBeUsedInsideModify("atOrElse"))
+    def atOrElse(idx: Int, default: => T): T = sys.error("")
+
     @compileTimeOnly(canOnlyBeUsedInsideModify("index"))
     def index(idx: Int): T = sys.error("")
   }
 
   trait QuicklensAtFunctor[F[_], T] {
     def at(fa: F[T], idx: Int)(f: T => T): F[T]
+    def atOrElse(fa: F[T], idx: Int, default: => T)(f: T => T): F[T]
     def index(fa: F[T], idx: Int)(f: T => T): F[T]
   }
 
@@ -269,6 +273,9 @@ package object quicklens extends LowPriorityImplicits {
     new QuicklensAtFunctor[F, T] {
       override def at(fa: F[T], idx: Int)(f: T => T): F[T] =
         fa.updated(idx, f(fa(idx)))
+      override def atOrElse(fa: F[T], idx: Int, default: => T)(f: T => T): F[T] =
+        if (idx >= 0 && idx < fa.size) fa.updated(idx, f(fa(idx)))
+        else fa :+ f(default)
       override def index(fa: F[T], idx: Int)(f: T => T): F[T] =
         if (idx < fa.size) fa.updated(idx, f(fa(idx))) else fa
     }

--- a/quicklens/src/main/scala-2.13-/com.softwaremill.quicklens/package.scala
+++ b/quicklens/src/main/scala-2.13-/com.softwaremill.quicklens/package.scala
@@ -274,7 +274,7 @@ package object quicklens extends LowPriorityImplicits {
       override def at(fa: F[T], idx: Int)(f: T => T): F[T] =
         fa.updated(idx, f(fa(idx)))
       override def atOrElse(fa: F[T], idx: Int, default: => T)(f: T => T): F[T] =
-        if (idx >= 0 && idx < fa.size) fa.updated(idx, f(fa(idx)))
+        if (fa.isDefinedAt(idx)) fa.updated(idx, f(fa(idx)))
         else fa :+ f(default)
       override def index(fa: F[T], idx: Int)(f: T => T): F[T] =
         if (idx < fa.size) fa.updated(idx, f(fa(idx))) else fa

--- a/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
+++ b/quicklens/src/main/scala-3/com/softwaremill/quicklens/QuicklensMacros.scala
@@ -118,7 +118,7 @@ object QuicklensMacros {
       def name: String
 
       def equiv(other: Any): Boolean = (this, other) match
-        case (Field(name1), Field(name2)) => name1 == name2
+        case (Field(name1), Field(name2))                       => name1 == name2
         case (Extension(term1, name1), Extension(term2, name2)) => term1 == term2 && name1 == name2
         case (FunctionDelegate(name1, _, typeTree1, args1), FunctionDelegate(name2, _, typeTree2, args2)) =>
           name1 == name2 && typeTree1.tpe == typeTree2.tpe && args1 == args2
@@ -140,7 +140,7 @@ object QuicklensMacros {
         case a @ Apply(TypeApply(Apply(TypeApply(Ident(s), _), idents), typeTrees), List(givn)) if methodSupported(s) =>
           idents.flatMap(toPath(_, focus)) :+ PathSymbol.FunctionDelegate(s, givn, typeTrees.last, List.empty)
         /** Extension method, which is called e.g. as x(_$1) */
-        case Apply(obj@Select(term, member), Seq(deep)) if obj.symbol.flags.is(Flags.ExtensionMethod) =>
+        case Apply(obj @ Select(term, member), Seq(deep)) if obj.symbol.flags.is(Flags.ExtensionMethod) =>
           toPath(deep, focus) :+ PathSymbol.Extension(term, member)
         /** Field access */
         case Apply(deep, idents) =>
@@ -182,8 +182,7 @@ object QuicklensMacros {
       val objSymbol = objTpe.matchingTypeSymbol
       // opaque types can find members of underlying types - ignore them (see https://github.com/scala/scala3/issues/22143)
       val fieldMemberSym = objSymbol.fieldMember(name)
-      if !objSymbol.flags.is(Flags.Deferred) && fieldMemberSym.exists then
-        Select(obj, fieldMemberSym)
+      if !objSymbol.flags.is(Flags.Deferred) && fieldMemberSym.exists then Select(obj, fieldMemberSym)
       else
         objSymbol.methodMember(name) match
           case List(m) =>
@@ -192,10 +191,15 @@ object QuicklensMacros {
             report.errorAndAbort(reportMethodError(objSymbol, name, lst))
     }
 
-    def reportMethodError(sym: Symbol, name: String, lst: List[Symbol], maybeArgNames: Option[Iterable[String]] = None): String = {
+    def reportMethodError(
+        sym: Symbol,
+        name: String,
+        lst: List[Symbol],
+        maybeArgNames: Option[Iterable[String]] = None
+    ): String = {
       (lst, maybeArgNames) match
-        case (Nil, _) => noSuchMember(sym.name, name)
-        case (lst, None) => multipleMatchingMethods(sym.name, name, lst)
+        case (Nil, _)              => noSuchMember(sym.name, name)
+        case (lst, None)           => multipleMatchingMethods(sym.name, name, lst)
         case (lst, Some(argNames)) => noSuitableMember(sym.name, name, argNames)
     }
 
@@ -212,14 +216,14 @@ object QuicklensMacros {
         val paramNames = msym.paramSymss.flatten.filter(_.isTerm).map(_.name)
         argNames.forall(paramNames.contains)
       } match
-        case List(m) => Some(m)
-        case Nil => None
-        case lst@(m :: _) =>
+        case List(m)        => Some(m)
+        case Nil            => None
+        case lst @ (m :: _) =>
           // if we have multiple matching copy methods, pick the synthetic one, if it exists, otherwise, pick any method
           val syntheticCopies = lst.filter(_.flags.is(Flags.Synthetic))
           syntheticCopies match
             case List(mSynth) => Some(mSynth)
-            case _ => Some(m)
+            case _            => Some(m)
     }
 
     def methodSymbolByNameAndArgs(sym: Symbol, name: String, argsMap: Map[String, Term]): Either[String, Symbol] = {
@@ -230,20 +234,25 @@ object QuicklensMacros {
       else Left(s"Deferred type ${sym.name}")
     }
 
-    /**
-      * @param argsMap normal methods receive one parameter list, extensions methods two, the first one contains the value
-      *                on which the extension is called
-      * */
+    /** @param argsMap
+      *   normal methods receive one parameter list, extensions methods two, the first one contains the value on which
+      *   the extension is called
+      */
     def callMethod(obj: Term, copy: Symbol, argsMap: List[Map[String, Term]]) = {
-      require(argsMap.size == 1 || argsMap.size == 2, s"argsMap.size should be either 1 or 2, got: ${argsMap.size} ($argsMap)")
+      require(
+        argsMap.size == 1 || argsMap.size == 2,
+        s"argsMap.size should be either 1 or 2, got: ${argsMap.size} ($argsMap)"
+      )
       val objTpe = obj.tpe.widenAll
       val objSymbol = objTpe.matchingTypeSymbol
 
       val typeParams = objTpe.typeArgs
       val copyTree: DefDef = copy.tree.asInstanceOf[DefDef]
-      val copyParams: List[(String, Option[Term])] = copyTree.termParamss.zip(argsMap)
+      val copyParams: List[(String, Option[Term])] = copyTree.termParamss
+        .zip(argsMap)
         .map((params, args) => params.params.map(_.name).map(name => name -> args.get(name)))
-        .flatten.toList
+        .flatten
+        .toList
 
       val args = copyParams.zipWithIndex.map { case ((n, v), _i) =>
         val i = _i + 1
@@ -255,7 +264,8 @@ object QuicklensMacros {
         n -> v.getOrElse(defaultMethod)
       }.toMap
 
-      val argLists: List[List[Term]] = copyTree.termParamss.take(argsMap.size).map(list => list.params.map(p => args(p.name)))
+      val argLists: List[List[Term]] =
+        copyTree.termParamss.take(argsMap.size).map(list => list.params.map(p => args(p.name)))
 
       if copyTree.termParamss.drop(argLists.size).exists(_.params.exists(!_.symbol.flags.is(Flags.Implicit))) then
         report.errorAndAbort(
@@ -281,8 +291,7 @@ object QuicklensMacros {
     }
 
     def findCompanionLikeObject(objSymbol: Symbol): Symbol = {
-      if objSymbol.companionModule.exists then
-        objSymbol.companionModule
+      if objSymbol.companionModule.exists then objSymbol.companionModule
       else
         val namedFromOwnerScope = objSymbol.owner.fieldMember(objSymbol.name)
         if namedFromOwnerScope.flags.is(Flags.Module) then namedFromOwnerScope
@@ -293,8 +302,7 @@ object QuicklensMacros {
       val companionSymbol = findCompanionLikeObject(sym)
       if companionSymbol.exists then
         companionSymbol.methodMember(methodName).filter(s => s.name == methodName && s.flags.is(Flags.ExtensionMethod))
-      else
-        Nil
+      else Nil
     }
 
     def isProductLike(sym: Symbol): Boolean = {
@@ -367,7 +375,9 @@ object QuicklensMacros {
                 callMethod(Ref(objCompanion), copy, argsWithObj)
               case None => report.errorAndAbort(error)
       } else
-        report.errorAndAbort(s"Unsupported source object: must be a case class, sealed trait or class with copy method, but got: $objSymbol of type ${objTpe.show} (${obj.show})")
+        report.errorAndAbort(
+          s"Unsupported source object: must be a case class, sealed trait or class with copy method, but got: $objSymbol of type ${objTpe.show} (${obj.show})"
+        )
     }
 
     def applyFunctionDelegate(
@@ -408,7 +418,8 @@ object QuicklensMacros {
         objTerm
 
       case (_: (PathSymbol.Field | PathSymbol.Extension), _) :: _ =>
-        val (fs, funs) = pathSymbols.span((ps, _) => ps.isInstanceOf[PathSymbol.Field] || ps.isInstanceOf[PathSymbol.Extension])
+        val (fs, funs) =
+          pathSymbols.span((ps, _) => ps.isInstanceOf[PathSymbol.Field] || ps.isInstanceOf[PathSymbol.Extension])
         val fields = fs.collect { case (p: (PathSymbol.Field | PathSymbol.Extension), trees) => p -> trees }
         val withCopiedFields: Term = caseClassCopy(owner, mod, objTerm, fields)
         accumulateToCopy(owner, mod, withCopiedFields, funs)

--- a/quicklens/src/main/scala-3/com/softwaremill/quicklens/package.scala
+++ b/quicklens/src/main/scala-3/com/softwaremill/quicklens/package.scala
@@ -154,8 +154,8 @@ package object quicklens {
       def map[A](fa: M[A], f: A => A): M[A] = {
         val mapped = fa.view.mapValues(f)
         (fa match {
-          case sfa: SortedMap[K, A]@unchecked => sfa.sortedMapFactory.from(mapped)(using sfa.ordering)
-          case _                    => mapped.to(fa.mapFactory)
+          case sfa: SortedMap[K, A] @unchecked => sfa.sortedMapFactory.from(mapped)(using sfa.ordering)
+          case _                               => mapped.to(fa.mapFactory)
         }).asInstanceOf[M[A]]
       }
     }
@@ -172,7 +172,8 @@ package object quicklens {
       def at[A](fa: S[A], f: A => A, idx: Int): S[A] =
         fa.updated(idx, f(fa(idx))).asInstanceOf[S[A]]
       def atOrElse[A](fa: S[A], f: A => A, idx: Int, default: => A): S[A] =
-        fa.updated(idx, f(fa.applyOrElse(idx, Function.const(default)))).asInstanceOf[S[A]]
+        if fa.isDefinedAt(idx) then fa.updated(idx, f(fa(idx))).asInstanceOf[S[A]]
+        else (fa :+ f(default)).asInstanceOf[S[A]]
       def index[A](fa: S[A], f: A => A, idx: Int): S[A] =
         if fa.isDefinedAt(idx) then fa.updated(idx, f(fa(idx))).asInstanceOf[S[A]] else fa
     }
@@ -183,7 +184,8 @@ package object quicklens {
         fa.updated(idx, f(fa(idx)))
       def atOrElse[A](fa: Array[A], f: A => A, idx: Int, default: => A): Array[A] =
         implicit val aClassTag: ClassTag[A] = fa.elemTag.asInstanceOf[ClassTag[A]]
-        fa.updated(idx, f(fa.applyOrElse(idx, Function.const(default))))
+        if fa.isDefinedAt(idx) then fa.updated(idx, f(fa(idx)))
+        else fa :+ f(default)
       def index[A](fa: Array[A], f: A => A, idx: Int): Array[A] =
         implicit val aClassTag: ClassTag[A] = fa.elemTag.asInstanceOf[ClassTag[A]]
         if fa.isDefinedAt(idx) then fa.updated(idx, f(fa(idx))) else fa

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExplicitCopyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExplicitCopyTest.scala
@@ -26,16 +26,16 @@ class ExplicitCopyTest extends AnyFlatSpec with Matchers {
   it should "modify a class that has a method with the same name as a field" in {
     final case class PathItem()
     final case class Paths(
-      pathItems: Map[String, PathItem] = Map.empty
+        pathItems: Map[String, PathItem] = Map.empty
     )
     final case class Docs(
-      paths: Paths = Paths()
+        paths: Paths = Paths()
     ) {
       def paths(paths: Paths): Docs = copy(paths = paths)
     }
     val docs = Docs()
     val r = docs.modify(_.paths.pathItems).using(m => m + ("a" -> PathItem()))
-    r.paths.pathItems should contain ("a" -> PathItem())
+    r.paths.pathItems should contain("a" -> PathItem())
   }
 
   it should "modify a case class with an additional explicit copy" in {

--- a/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
+++ b/quicklens/src/test/scala-3/com/softwaremill/quicklens/test/ExtensionCopyTest.scala
@@ -39,7 +39,7 @@ class ExtensionCopyTest extends AnyFlatSpec with Matchers {
     val a = VecSimple(1, 2)
     val b = a.modify(_.xMember).using(_ + 10)
     b.xMember shouldEqual 11
-    */
+     */
   }
 
   it should "modify a simple class with an extension copy method in companion" in {

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyArrayAtOrElseTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/ModifyArrayAtOrElseTest.scala
@@ -1,0 +1,18 @@
+package com.softwaremill.quicklens
+
+import com.softwaremill.quicklens.TestData._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ModifyArrayAtOrElseTest extends AnyFlatSpec with Matchers {
+
+  it should "modify an existing element using atOrElse" in {
+    modify(ar1)(_.atOrElse(2, A3(A4(A5("default")))).a4.a5.name).using(duplicate) should be(l1at2dup)
+  }
+
+  it should "append the modified default for a missing index" in {
+    modify(ar1)(_.atOrElse(10, A3(A4(A5("def")))).a4.a5.name).using(duplicate) should be(
+      l1 :+ A3(A4(A5("defdef")))
+    )
+  }
+}

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/ModifySeqAtOrElseTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/ModifySeqAtOrElseTest.scala
@@ -20,4 +20,18 @@ class ModifySeqAtOrElseTest extends AnyFlatSpec with Matchers {
       List(Item("a"), Item("b"), Item("DEFAULT"))
     )
   }
+
+  it should "append the modified default on an empty sequence" in {
+    val items = List.empty[Item]
+    modify(items)(_.atOrElse(0, Item("default")).name).using(_.toUpperCase) should be(
+      List(Item("DEFAULT"))
+    )
+  }
+
+  it should "append the modified default for a negative index" in {
+    val items = List(Item("a"), Item("b"))
+    modify(items)(_.atOrElse(-1, Item("default")).name).using(_.toUpperCase) should be(
+      List(Item("a"), Item("b"), Item("DEFAULT"))
+    )
+  }
 }

--- a/quicklens/src/test/scala/com/softwaremill/quicklens/ModifySeqAtOrElseTest.scala
+++ b/quicklens/src/test/scala/com/softwaremill/quicklens/ModifySeqAtOrElseTest.scala
@@ -1,0 +1,23 @@
+package com.softwaremill.quicklens
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ModifySeqAtOrElseTest extends AnyFlatSpec with Matchers {
+
+  case class Item(name: String)
+
+  it should "modify an existing element using atOrElse" in {
+    val items = List(Item("a"), Item("b"))
+    modify(items)(_.atOrElse(1, Item("default")).name).using(_.toUpperCase) should be(
+      List(Item("a"), Item("B"))
+    )
+  }
+
+  it should "use the default for a missing index instead of throwing" in {
+    val items = List(Item("a"), Item("b"))
+    modify(items)(_.atOrElse(5, Item("default")).name).using(_.toUpperCase) should be(
+      List(Item("a"), Item("b"), Item("DEFAULT"))
+    )
+  }
+}


### PR DESCRIPTION
Fixes #301: `.atOrElse` now works for sequences and arrays, addressing the IndexOutOfBoundsException thrown when accessing missing indices.

## Changes

Implemented `.atOrElse(idx, default)` across all Scala versions (2.13-, 2.13+, and 3) for both sequences and arrays. When the index exists, it behaves identically to `.at`. When the index is out of bounds, the modified default is appended once to the end of the sequence, providing a sensible fallback without requiring multiple insertions.

## Testing

Added comprehensive test suites covering:
- Modifying existing elements at valid indices
- Using the default for out-of-bounds indices (including negative indices)
- Appending to empty sequences
- Both sequence and array implementations

The fix resolves the previous behavior of throwing exceptions and aligns with the documented API contract.

Closes softwaremill/quicklens#301.